### PR TITLE
test: add cron job for pos e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,17 @@
 name: e2e
 on:
+  schedule:
+    - cron: "0 0 * * *"
   workflow_dispatch:
+    inputs:
+      ethTestnetType:
+        description: 'Eth testnet type'
+        required: false
+        default: 'pow'
+        type: choice
+        options:
+        - pow
+        - pos
   push:
     branches: [main]
   pull_request:
@@ -17,7 +28,6 @@ on:
 env:
   FOUNDRY_PROFILE: ci
   SP1_OPERATOR_REV: 7b302f7493cfd7dbcbcd7c8ece5ba1e57d6c8104
-  ETH_TESTNET_TYPE: pow
 permissions:
   contents: read
 
@@ -97,6 +107,7 @@ jobs:
       - name: Run Tests
         env:
           SP1_PRIVATE_KEY: ${{ secrets.SP1_PRIVATE_KEY }}
+          ETH_TESTNET_TYPE: ${{ (github.event_name == 'schedule' && 'pos') || github.event.inputs.ethTestnetType || 'pow' }}
         run: |
           cd e2e/interchaintestv8
           go test -v -mod=readonly . -run '^${{ matrix.test }}$' -timeout 40m

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,11 +79,7 @@ jobs:
         run: |
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt update
-          if [ "${{ inputs.version }}" = "latest" ]; then
-            sudo apt install kurtosis-cli
-          else
-            sudo apt install kurtosis-cli=${{ inputs.kurtosis_version }}
-          fi
+          sudo apt install kurtosis-cli
           kurtosis analytics disable
           echo "$(dirname $(which kurtosis))" >> $GITHUB_PATH
         shell: bash

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,9 +79,9 @@ jobs:
         run: |
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt update
-          sudo apt install kurtosis-cli
-          kurtosis analytics disable
+          sudo apt install kurtosis-cli=1.3.0 # Must match the kurtosis library version we use in the e2e tests
           kurtosis engine start
+          kurtosis analytics disable
           echo "$(dirname $(which kurtosis))" >> $GITHUB_PATH
         shell: bash
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,6 +75,19 @@ jobs:
           check-latest: true
           cache-dependency-path: e2e/interchaintestv8/go.sum
 
+      - name: Setup Kurtosis
+        run: |
+          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          sudo apt update
+          if [ "${{ inputs.version }}" = "latest" ]; then
+            sudo apt install kurtosis-cli
+          else
+            sudo apt install kurtosis-cli=${{ inputs.kurtosis_version }}
+          fi
+          kurtosis analytics disable
+          echo "$(dirname $(which kurtosis))" >> $GITHUB_PATH
+        shell: bash
+
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,6 +61,8 @@ jobs:
           - TestWithIbcEurekaTestSuite/TestICS20TransferTimeoutFromEthereumToCosmosChain
     name: ${{ matrix.test }}
     runs-on: ubuntu-latest
+    env:
+      ETH_TESTNET_TYPE: ${{ github.event.inputs.ethTestnetType || (github.event_name == 'schedule' && 'pos') || 'pow' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -74,16 +76,6 @@ jobs:
           go-version: "1.22"
           check-latest: true
           cache-dependency-path: e2e/interchaintestv8/go.sum
-
-      - name: Setup Kurtosis
-        run: |
-          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-          sudo apt update
-          sudo apt install kurtosis-cli=1.3.0 # Must match the kurtosis library version we use in the e2e tests
-          kurtosis engine start
-          kurtosis analytics disable
-          echo "$(dirname $(which kurtosis))" >> $GITHUB_PATH
-        shell: bash
 
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1
@@ -114,10 +106,20 @@ jobs:
           command: install
           args: --git https://github.com/cosmos/sp1-ics07-tendermint --rev ${{ env.SP1_OPERATOR_REV }} sp1-ics07-tendermint-operator --bin operator --locked
 
+      - name: Setup Kurtosis
+        if: env.ETH_TESTNET_TYPE == 'pos'
+        run: |
+          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          sudo apt update
+          sudo apt install kurtosis-cli=1.3.0 # Must match the kurtosis library version we use in the e2e tests
+          kurtosis engine start
+          kurtosis analytics disable
+          echo "$(dirname $(which kurtosis))" >> $GITHUB_PATH
+        shell: bash
+
       - name: Run Tests
         env:
           SP1_PRIVATE_KEY: ${{ secrets.SP1_PRIVATE_KEY }}
-          ETH_TESTNET_TYPE: ${{ (github.event_name == 'schedule' && 'pos') || github.event.inputs.ethTestnetType || 'pow' }}
         run: |
           cd e2e/interchaintestv8
           go test -v -mod=readonly . -run '^${{ matrix.test }}$' -timeout 40m

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,6 +81,7 @@ jobs:
           sudo apt update
           sudo apt install kurtosis-cli
           kurtosis analytics disable
+          kurtosis engine start
           echo "$(dirname $(which kurtosis))" >> $GITHUB_PATH
         shell: bash
 

--- a/e2e/interchaintestv8/e2esuite/light_clients.go
+++ b/e2e/interchaintestv8/e2esuite/light_clients.go
@@ -70,8 +70,18 @@ func (s *TestSuite) UpdateEthClient(ctx context.Context, ibcContractAddress stri
 
 		targetPeriod = finalityUpdate.Data.AttestedHeader.Beacon.Slot / spec.Period()
 
+		lightClientUpdates, err := eth.BeaconAPIClient.GetLightClientUpdates(trustedPeriod+1, targetPeriod-trustedPeriod)
+		s.Require().NoError(err)
+		var highestUpdateSlot uint64
+		for _, update := range lightClientUpdates {
+			if update.Data.AttestedHeader.Beacon.Slot > highestUpdateSlot {
+				highestUpdateSlot = update.Data.AttestedHeader.Beacon.Slot
+			}
+		}
+
 		return finalityUpdate.Data.FinalizedHeader.Beacon.Slot > uint64(updateTo) &&
-				targetPeriod > trustedPeriod,
+				targetPeriod > trustedPeriod &&
+				highestUpdateSlot > uint64(updateTo),
 			nil
 	})
 	s.Require().NoError(err)

--- a/e2e/interchaintestv8/e2esuite/light_clients.go
+++ b/e2e/interchaintestv8/e2esuite/light_clients.go
@@ -64,6 +64,7 @@ func (s *TestSuite) UpdateEthClient(ctx context.Context, ibcContractAddress stri
 
 	var finalityUpdate ethereum.FinalityUpdateJSONResponse
 	var targetPeriod uint64
+	// Now we need to wait for finalization and light client update availability to be after updateTo
 	err = testutil.WaitForCondition(8*time.Minute, 5*time.Second, func() (bool, error) {
 		finalityUpdate, err = eth.BeaconAPIClient.GetFinalityUpdate()
 		s.Require().NoError(err)


### PR DESCRIPTION
Added a cron job to run once per day (midnight) with e2e tests with PoS.

Also added a way to run the tests manually with manual dispatch (and select the pow or pos): https://github.com/cosmos/solidity-ibc-eureka/actions/runs/11629265273