### PR TITLE
fix: change from u8 to u16 conversion to prevent key-value pairs length overflow

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -87,11 +87,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1732521221,
-        "narHash": "sha256-2ThgXBUXAE1oFsVATK1ZX9IjPcS4nKFOAjhPNKuiMn0=",
+        "lastModified": 1738410390,
+        "narHash": "sha256-xvTo0Aw0+veek7hvEVLzErmJyQkEcRk6PSR4zsRQFEc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+        "rev": "3a228057f5b619feb3186e986dbe76278d707b6e",
         "type": "github"
       },
       "original": {

--- a/packages/sp1-ics07-tendermint-prover/src/prover.rs
+++ b/packages/sp1-ics07-tendermint-prover/src/prover.rs
@@ -136,11 +136,11 @@ where
         kv_proofs: Vec<(Vec<Vec<u8>>, Vec<u8>, MerkleProof)>,
     ) -> SP1ProofWithPublicValues {
         assert!(!kv_proofs.is_empty(), "No key-value pairs to prove");
-        let len = u8::try_from(kv_proofs.len()).expect("too many key-value pairs");
+        let len = u16::try_from(kv_proofs.len()).expect("too many key-value pairs");
 
         let mut stdin = SP1Stdin::new();
         stdin.write_slice(commitment_root);
-        stdin.write_vec(vec![len]);
+        stdin.write_vec(len.to_le_bytes().to_vec()); 
         for (path, value, proof) in kv_proofs {
             stdin.write_vec(bincode::serialize(&path).unwrap());
             stdin.write_vec(value);
@@ -172,7 +172,7 @@ where
         kv_proofs: Vec<(Vec<Vec<u8>>, Vec<u8>, MerkleProof)>,
     ) -> SP1ProofWithPublicValues {
         assert!(!kv_proofs.is_empty(), "No key-value pairs to prove");
-        let len = u8::try_from(kv_proofs.len()).expect("too many key-value pairs");
+        let len = u16::try_from(kv_proofs.len()).expect("too many key-value pairs");
         // Encode the inputs into our program.
         let encoded_1 = client_state.abi_encode();
         let encoded_2 = trusted_consensus_state.abi_encode();
@@ -187,7 +187,7 @@ where
         stdin.write_vec(encoded_2);
         stdin.write_vec(encoded_3);
         stdin.write_vec(encoded_4);
-        stdin.write_vec(vec![len]);
+        stdin.write_vec(len.to_le_bytes().to_vec()); 
         for (path, value, proof) in kv_proofs {
             stdin.write_vec(bincode::serialize(&path).unwrap());
             stdin.write_vec(value);

--- a/packages/sp1-ics07-tendermint-prover/src/prover.rs
+++ b/packages/sp1-ics07-tendermint-prover/src/prover.rs
@@ -140,7 +140,7 @@ where
 
         let mut stdin = SP1Stdin::new();
         stdin.write_slice(commitment_root);
-        stdin.write_vec(len.to_le_bytes().to_vec()); 
+        stdin.write_slice(&len.to_le_bytes());
         for (path, value, proof) in kv_proofs {
             stdin.write_vec(bincode::serialize(&path).unwrap());
             stdin.write_vec(value);
@@ -187,7 +187,7 @@ where
         stdin.write_vec(encoded_2);
         stdin.write_vec(encoded_3);
         stdin.write_vec(encoded_4);
-        stdin.write_vec(len.to_le_bytes().to_vec()); 
+        stdin.write_slice(&len.to_le_bytes());
         for (path, value, proof) in kv_proofs {
             stdin.write_vec(bincode::serialize(&path).unwrap());
             stdin.write_vec(value);

--- a/programs/sp1-programs/membership/src/main.rs
+++ b/programs/sp1-programs/membership/src/main.rs
@@ -25,7 +25,8 @@ pub fn main() {
     let app_hash: [u8; 32] = encoded_1.try_into().unwrap();
 
     // encoded_2 is the number of key-value pairs we want to verify
-    let request_len = sp1_zkvm::io::read_vec()[0];
+    let encoded_2 = sp1_zkvm::io::read_vec();
+    let request_len = u16::from_le_bytes(encoded_2.try_into().unwrap());
     assert!(request_len != 0);
 
     let request_iter = (0..request_len).map(|_| {

--- a/programs/sp1-programs/uc-and-membership/src/main.rs
+++ b/programs/sp1-programs/uc-and-membership/src/main.rs
@@ -31,7 +31,8 @@ pub fn main() {
     let encoded_3 = sp1_zkvm::io::read_vec();
     let encoded_4 = sp1_zkvm::io::read_vec();
     // encoded_5 is the number of key-value pairs we want to verify
-    let request_len = sp1_zkvm::io::read_vec()[0];
+    let encoded_5 = sp1_zkvm::io::read_vec();
+    let request_len = u16::from_le_bytes(encoded_5.try_into().unwrap());
     assert!(request_len != 0);
 
     // input 1: the client state


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: https://github.com/cosmos/solidity-ibc-eureka/issues/250

<!--

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sp1-contracts to v4.0.0
chore: removed unused variables
e2e: adding e2e tests for ics20
docs: ics27 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Wrote unit and integration tests.
- [ ] Added relevant natspec and `godoc` comments.
- [ ] Provide a [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) to follow the repository standards.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
