### PR TITLE
feat(relayer): add basic health check and reflection service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6047,6 +6047,8 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+ "tonic-health",
+ "tonic-reflection",
  "tracing",
  "tracing-subscriber",
 ]
@@ -7267,6 +7269,32 @@ dependencies = [
  "prost-types",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
+dependencies = [
+ "async-stream",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "878d81f52e7fcfd80026b7fdb6a9b578b3c3653ba987f87f0dce4b64043cba27"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/programs/relayer/Cargo.toml
+++ b/programs/relayer/Cargo.toml
@@ -28,6 +28,8 @@ tendermint-rpc = { workspace = true }
 
 sp1-sdk = { workspace = true, default-features = true }
 sp1-prover = { workspace = true }
+tonic-health = "0.12.3"
+tonic-reflection = "0.12.3"
 
 [build-dependencies]
 tonic-build = { workspace = true, default-features = true }

--- a/programs/relayer/build.rs
+++ b/programs/relayer/build.rs
@@ -1,6 +1,12 @@
+use std::env;
+use std::path::PathBuf;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
     tonic_build::configure()
         .build_server(true)
+        .file_descriptor_set_path(out_dir.join("relayer_descriptor.bin"))
         .compile_protos(&["proto/relayer/relayer.proto"], &["proto/relayer"])?;
     Ok(())
 }

--- a/programs/relayer/src/core/builder.rs
+++ b/programs/relayer/src/core/builder.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use super::modules::RelayerModule;
 use crate::{
     api::{
         self,
@@ -10,7 +11,6 @@ use crate::{
     cli::config::RelayerConfig,
 };
 use tonic::{transport::Server, Request, Response};
-use super::modules::RelayerModule;
 
 /// The `RelayerBuilder` struct is used to build the relayer.
 #[derive(Default)]
@@ -75,7 +75,9 @@ impl RelayerBuilder {
             );
         }
 
-        health_reporter.set_serving::<RelayerServiceServer<Relayer>>().await;
+        health_reporter
+            .set_serving::<RelayerServiceServer<Relayer>>()
+            .await;
 
         // Start the gRPC server
         Server::builder()

--- a/programs/relayer/src/core/builder.rs
+++ b/programs/relayer/src/core/builder.rs
@@ -10,7 +10,6 @@ use crate::{
     cli::config::RelayerConfig,
 };
 use tonic::{transport::Server, Request, Response};
-
 use super::modules::RelayerModule;
 
 /// The `RelayerBuilder` struct is used to build the relayer.
@@ -55,6 +54,13 @@ impl RelayerBuilder {
         tracing::info!(%socket_addr, "Starting relayer...");
         let socket_addr = socket_addr.parse::<std::net::SocketAddr>()?;
 
+        let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
+
+        let reflection_service = tonic_reflection::server::Builder::configure()
+            .register_encoded_file_descriptor_set(tonic_health::pb::FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(api::FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+
         let mut relayer = Relayer::default();
         // Iterate through all configured modules
         for c in config.modules.into_iter().filter(|c| c.enabled) {
@@ -69,9 +75,13 @@ impl RelayerBuilder {
             );
         }
 
+        health_reporter.set_serving::<RelayerServiceServer<Relayer>>().await;
+
         // Start the gRPC server
         Server::builder()
             .add_service(RelayerServiceServer::new(relayer))
+            .add_service(health_service)
+            .add_service(reflection_service)
             .serve(socket_addr)
             .await?;
 

--- a/programs/relayer/src/lib.rs
+++ b/programs/relayer/src/lib.rs
@@ -7,7 +7,8 @@ pub mod api {
     tonic::include_proto!("relayer");
 
     #[doc = "The file descriptor set for the relayer service."]
-    pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("relayer_descriptor");
+    pub const FILE_DESCRIPTOR_SET: &[u8] =
+        tonic::include_file_descriptor_set!("relayer_descriptor");
 }
 
 pub mod cli;

--- a/programs/relayer/src/lib.rs
+++ b/programs/relayer/src/lib.rs
@@ -5,6 +5,9 @@
 #[allow(clippy::nursery, clippy::pedantic)]
 pub mod api {
     tonic::include_proto!("relayer");
+
+    #[doc = "The file descriptor set for the relayer service."]
+    pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("relayer_descriptor");
 }
 
 pub mod cli;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
Adds a reflection and health service to the Tonic gRPC server. Right now, the health checks don't really reflect the service status, since we don't do any upstream service health checks, but I wanted to get it in here for 2 reasons - unblocking deployments in Kubernetes + allowing you to add more proper healthchecking in the future.

---

- [x] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [x] Wrote unit and integration tests.
- [x] Added relevant natspec and `godoc` comments.
- [x] Provide a [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) to follow the repository standards.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
