### PR TITLE
 Fix Typographical and Readability Issues in Documentation

### DIFF
--- a/programs/cw-ics08-wasm-eth/src/msg.rs
+++ b/programs/cw-ics08-wasm-eth/src/msg.rs
@@ -163,7 +163,7 @@ pub struct StatusMsg {}
 /// Height of the ethereum chain
 #[cw_serde]
 pub struct Height {
-    /// The revision that the client is currently on
+    /// The revision the client is currently on
     /// Always zero in the ethereum light client
     #[serde(default)]
     pub revision_number: u64,

--- a/programs/cw-ics08-wasm-eth/src/sudo.rs
+++ b/programs/cw-ics08-wasm-eth/src/sudo.rs
@@ -86,7 +86,7 @@ pub fn verify_non_membership(
 /// This function is always called after the verify client message, so
 /// we can assume the client message is valid and that the consensus state can be updated
 /// # Errors
-/// Returns an error if deserialization failes or if the light client update logic fails
+/// Returns an error if deserialization fails or if the light client update logic fails
 /// # Returns
 /// The updated slot (called height in regular IBC terms)
 #[allow(clippy::needless_pass_by_value)]


### PR DESCRIPTION
In the msg.rs file:

Old: /// The revision that the client is currently on
New: /// The revision the client is currently on
Reason: The word "that" was removed to improve readability and make the sentence more concise.
In the sudo.rs file:

Old: /// Returns an error if deserialization failes or if the light client update logic fails
New: /// Returns an error if deserialization fails or if the light client update logic fails
