### PR TITLE
fix: add multiple pausers to deployment helpers

### DIFF
--- a/scripts/SP1ICS07Tendermint.s.sol
+++ b/scripts/SP1ICS07Tendermint.s.sol
@@ -7,9 +7,9 @@ import { IICS07TendermintMsgs } from "../contracts/light-clients/msgs/IICS07Tend
 import { SP1ICS07Tendermint } from "../contracts/light-clients/SP1ICS07Tendermint.sol";
 import { Script } from "forge-std/Script.sol";
 import { stdJson } from "forge-std/StdJson.sol";
-import { DeploySP1ICS07Tendermint } from "./deployments/DeploySP1ICS07Tendermint.sol";
+import { Deployments } from "./helpers/Deployments.sol";
 
-contract SP1TendermintScript is Script, IICS07TendermintMsgs, DeploySP1ICS07Tendermint {
+contract SP1TendermintScript is Script, IICS07TendermintMsgs, Deployments {
     using stdJson for string;
 
     address public verifier;
@@ -26,11 +26,49 @@ contract SP1TendermintScript is Script, IICS07TendermintMsgs, DeploySP1ICS07Tend
         string memory root = vm.projectRoot();
         string memory path = string.concat(root, SP1_GENESIS_DIR, "genesis.json");
         string memory json = vm.readFile(path);
+
         SP1ICS07TendermintDeployment memory genesis = loadSP1ICS07TendermintDeployment(json, "");
         genesis.verifier = vm.envOr("VERIFIER", string(""));
 
         vm.startBroadcast();
-        (ics07Tendermint, trustedConsensusState, trustedClientState) = deploySP1ICS07Tendermint(genesis);
+        IICS07TendermintMsgs.ConsensusState memory trustedConsensusState =
+                            abi.decode(genesis.trustedConsensusState, (IICS07TendermintMsgs.ConsensusState));
+        IICS07TendermintMsgs.ClientState memory trustedClientState =
+                            abi.decode(genesis.trustedClientState, (IICS07TendermintMsgs.ClientState));
+
+        address verifier = address(0);
+
+        if (keccak256(bytes(genesis.verifier)) == keccak256(bytes("mock"))) {
+            verifier = address(new SP1MockVerifier());
+        } else if (bytes(genesis.verifier).length > 0) {
+            (bool success, address verifierAddr) = Strings.tryParseAddress(genesis.verifier);
+            require(success, string.concat("Invalid verifier address: ", genesis.verifier));
+
+            if (verifierAddr == address(0)) {
+                revert("Verifier address is zero");
+            }
+
+            verifier = verifierAddr;
+        } else if (trustedClientState.zkAlgorithm == IICS07TendermintMsgs.SupportedZkAlgorithm.Plonk) {
+            verifier = address(new SP1VerifierPlonk());
+        } else if (trustedClientState.zkAlgorithm == IICS07TendermintMsgs.SupportedZkAlgorithm.Groth16) {
+            verifier = address(new SP1VerifierGroth16());
+        } else {
+            revert("Unsupported zk algorithm");
+        }
+
+        // Deploy the SP1 ICS07 Tendermint light client
+        SP1ICS07Tendermint ics07Tendermint = new SP1ICS07Tendermint(
+            genesis.updateClientVkey,
+            genesis.membershipVkey,
+            genesis.ucAndMembershipVkey,
+            genesis.misbehaviourVkey,
+            verifier,
+            genesis.trustedClientState,
+            keccak256(abi.encode(trustedConsensusState))
+        );
+
+
         vm.stopBroadcast();
 
         bytes memory clientStateBz = ics07Tendermint.getClientState();

--- a/scripts/helpers/Deployments.sol
+++ b/scripts/helpers/Deployments.sol
@@ -106,8 +106,8 @@ abstract contract Deployments {
         address ibcERC20Implementation;
 
         // admin control
-        address[] memory pausers;
-        address[] memory unpausers;
+        address[] pausers;
+        address[] unpausers;
         address permit2;
         address proxy;
     }
@@ -120,7 +120,6 @@ abstract contract Deployments {
     pure
     returns (ProxiedICS20TransferDeployment memory)
     {
-        // abi.decode(vm.parseJson(json, ".ics20Transfer"), (ProxiedICS20TransferDeployment));
         ProxiedICS20TransferDeployment memory fixture = ProxiedICS20TransferDeployment({
             escrowImplementation: vm.parseJsonAddress(json, ".ics20Transfer.escrowImplementation"),
             ibcERC20Implementation: vm.parseJsonAddress(json, ".ics20Transfer.ibcERC20Implementation"),

--- a/scripts/helpers/Deployments.sol
+++ b/scripts/helpers/Deployments.sol
@@ -106,8 +106,8 @@ abstract contract Deployments {
         address ibcERC20Implementation;
 
         // admin control
-        address pauser;
-        address unpauser;
+        address[] memory pausers;
+        address[] memory unpausers;
         address permit2;
         address proxy;
     }
@@ -126,8 +126,8 @@ abstract contract Deployments {
             ibcERC20Implementation: vm.parseJsonAddress(json, ".ics20Transfer.ibcERC20Implementation"),
             ics26Router: vm.parseJsonAddress(json, ".ics20Transfer.ics26Router"),
             implementation: vm.parseJsonAddress(json, ".ics20Transfer.implementation"),
-            pauser: vm.parseJsonAddress(json, ".ics20Transfer.pauser"),
-            unpauser: vm.parseJsonAddress(json, ".ics20Transfer.unpauser"),
+            pausers: vm.parseJsonAddressArray(json, ".ics20Transfer.pausers"),
+            unpausers: vm.parseJsonAddressArray(json, ".ics20Transfer.unpausers"),
             permit2: vm.parseJsonAddress(json, ".ics20Transfer.permit2"),
             proxy: vm.parseJsonAddress(json, ".ics20Transfer.proxy")
         });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Fixes the deployment scripts for E2E tests and also adds support for multiple pausers / unpausers on deploy time.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Wrote unit and integration tests.
- [ ] Added relevant natspec and `godoc` comments.
- [ ] Provide a [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) to follow the repository standards.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
