### PR TITLE
Fix typos

### DIFF
--- a/packages/ethereum/tree_hash/src/merkle_hasher.rs
+++ b/packages/ethereum/tree_hash/src/merkle_hasher.rs
@@ -158,7 +158,7 @@ impl MerkleHasher {
     /// Instantiate a hasher for a tree with a given number of leaves.
     ///
     /// `num_leaves` will be rounded to the next power of two. E.g., if `num_leaves == 6`, then the
-    /// tree will _actually_ be able to accomodate 8 leaves and the resulting hasher is exactly the
+    /// tree will _actually_ be able to accommodate 8 leaves and the resulting hasher is exactly the
     /// same as one that was instantiated with `Self::with_leaves(8)`.
     ///
     /// ## Notes

--- a/packages/ethereum/types/README.md
+++ b/packages/ethereum/types/README.md
@@ -1,5 +1,5 @@
 # `ethereum-types`
 
-This crate contains ethereum types that are compatible with standard API endpoints such as the beacon API and the exeuction API. 
+This crate contains ethereum types that are compatible with standard API endpoints such as the beacon API and the execution API. 
 
 It also contains implementations for these types to enable their use in different use cases.


### PR DESCRIPTION


**Description:**
This PR fixes two typos:
- Corrects "accomodate" to "accommodate" in merkle_hasher.rs
- Corrects "execuction" to "execution" in types/README.md

The changes are purely cosmetic and do not affect any functionality.
