### PR TITLE
test: fix failing timeout in full e2e

### DIFF
--- a/packages/ethereum/light-client/src/client_state.rs
+++ b/packages/ethereum/light-client/src/client_state.rs
@@ -63,7 +63,8 @@ impl ClientState {
         timestamp_seconds
             .checked_sub(self.genesis_time)?
             .checked_div(self.seconds_per_slot)?
-            .checked_add(self.genesis_slot)
+            .checked_add(self.genesis_slot)?
+            .checked_add(1)
     }
 
     /// Returns the epoch at a given `slot`.

--- a/packages/ethereum/light-client/src/client_state.rs
+++ b/packages/ethereum/light-client/src/client_state.rs
@@ -63,8 +63,7 @@ impl ClientState {
         timestamp_seconds
             .checked_sub(self.genesis_time)?
             .checked_div(self.seconds_per_slot)?
-            .checked_add(self.genesis_slot)?
-            .checked_add(1)
+            .checked_add(self.genesis_slot)
     }
 
     /// Returns the epoch at a given `slot`.

--- a/packages/relayer-lib/src/tx_builder/eth_to_cosmos.rs
+++ b/packages/relayer-lib/src/tx_builder/eth_to_cosmos.rs
@@ -362,6 +362,7 @@ where
             .filter_map(|e| {
                 ethereum_client_state
                     .compute_slot_at_timestamp(e.packet.as_ref()?.timeout_timestamp)
+                    .and_then(|slot| slot.checked_add(1))
             })
             .max();
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #516

Full e2e run from this branch: https://github.com/cosmos/solidity-ibc-eureka/actions/runs/14955457589

<!--

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sp1-contracts to v4.0.0
chore: removed unused variables
e2e: adding e2e tests for ics20
docs: ics27 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Wrote unit and integration tests.
- [ ] Added relevant natspec and `godoc` comments.
- [ ] Provide a [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) to follow the repository standards.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
