### PR TITLE
ci: use groth16 by default in e2e + add proof type choice

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -10,6 +10,14 @@ on:
         options:
           - local
           - cw-ics08-wasm-eth-v1.2.0
+      proof-type:
+        description: 'Proof type'
+        type: choice
+        required: true
+        default: 'groth16'
+        options:
+          - groth16
+          - plonk
   schedule:
     - cron: '0 0 */3 * *'  # Run every 3 days at midnight UTC
 
@@ -22,6 +30,7 @@ env:
   ETH_TESTNET_TYPE: pos
   SP1_PROVER: network
   ETHEREUM_POS_NETWORK_PRESET: mainnet
+  E2E_PROOF_TYPE: ${{ inputs.proof-type }}
   E2E_PRIVATE_CLUSTER: true
   E2E_WASM_LIGHT_CLIENT_TAG: ${{ inputs.wasm-eth-light-client-tag }}
 permissions:

--- a/.github/workflows/e2e-minimal.yml
+++ b/.github/workflows/e2e-minimal.yml
@@ -10,6 +10,14 @@ on:
         options:
           - local
           - cw-ics08-wasm-eth-v1.2.0
+      proof-type:
+        description: 'Proof type'
+        type: choice
+        required: true
+        default: 'groth16'
+        options:
+          - groth16
+          - plonk
   push:
     branches:
       - main
@@ -23,6 +31,7 @@ env:
   ETH_TESTNET_TYPE: pos
   SP1_PROVER: network
   ETHEREUM_POS_NETWORK_PRESET: minimal
+  E2E_PROOF_TYPE: ${{ inputs.proof-type }}
   E2E_PRIVATE_CLUSTER: true
   E2E_WASM_LIGHT_CLIENT_TAG: ${{ inputs.wasm-eth-light-client-tag }}
 permissions:

--- a/.github/workflows/e2e-mock.yml
+++ b/.github/workflows/e2e-mock.yml
@@ -21,6 +21,7 @@ env:
   FOUNDRY_PROFILE: ci
   ETH_TESTNET_TYPE: pow
   SP1_PROVER: mock
+  E2E_PROOF_TYPE: groth16
 permissions:
   contents: read
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: IBCSOL-231

<!--

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sp1-contracts to v4.0.0
chore: removed unused variables
e2e: adding e2e tests for ics20
docs: ics27 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Wrote unit and integration tests.
- [ ] Added relevant natspec and `godoc` comments.
- [ ] Provide a [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) to follow the repository standards.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
