### PR TITLE
spike: Eventloop of attestation actor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ bacon.toml
 programs/relayer/config.json
 scripts/genesis.json
 network_params.yaml
+.vscode/launch.json

--- a/spike/attastator/server.go
+++ b/spike/attastator/server.go
@@ -9,7 +9,8 @@ import (
 	"time"
 )
 
-type Server struct {
+// L2Proxy is used to simulate connection to a L2 full node.
+type L2Proxy struct {
 	MonotonicHeight int64
 	BlockTime       time.Duration
 	mu              sync.Mutex
@@ -23,15 +24,15 @@ type L2State struct {
 	Err       error
 }
 
-func New(blockTime time.Duration, initialHeight int64) *Server {
-	return &Server{
+func New(blockTime time.Duration, initialHeight int64) *L2Proxy {
+	return &L2Proxy{
 		MonotonicHeight: initialHeight,
 		BlockTime:       blockTime,
 		mu:              sync.Mutex{},
 	}
 }
 
-func (s *Server) Start(ctx context.Context) {
+func (s *L2Proxy) Start(ctx context.Context) {
 	tkr := time.NewTicker(s.BlockTime)
 	go func() {
 		defer tkr.Stop()
@@ -48,7 +49,7 @@ func (s *Server) Start(ctx context.Context) {
 	}()
 }
 
-func (s *Server) QueryL2() (state L2State) {
+func (s *L2Proxy) QueryL2() (state L2State) {
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 	defer func() {
 		if r := recover(); r != nil {

--- a/spike/attastator/server.go
+++ b/spike/attastator/server.go
@@ -49,6 +49,7 @@ func (s *Server) Start(ctx context.Context) {
 }
 
 func (s *Server) QueryL2() (state L2State) {
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 	defer func() {
 		if r := recover(); r != nil {
 			state.Err = fmt.Errorf("panic: %v", r)
@@ -56,21 +57,25 @@ func (s *Server) QueryL2() (state L2State) {
 	}()
 
 	// Simulate Query to L2 and attastation
-	busyLoop := rand.Int63n(20000000000)
+	busyLoop := rnd.Int63n(10000000000)
 
 	cnt := int64(0)
 	// Simulate Long running attastation Process
 	for range busyLoop {
 		cnt++
 	}
-	if busyLoop < 10000000000 {
+	if busyLoop < 3000000000 {
 		panic("AAAAAAA")
 	}
 
+	s.mu.Lock()
+	h := s.MonotonicHeight
+	s.mu.Unlock()
+
 	state = L2State{
-		Height:    s.MonotonicHeight,
+		Height:    h,
 		StateRoot: RandString(32),
-		Signature: RandomBytes(64),
+		Signature: RandomBytes(5),
 		TimeStamp: time.Now(),
 		Err:       nil,
 	}

--- a/spike/attastator/server.go
+++ b/spike/attastator/server.go
@@ -1,0 +1,101 @@
+package attastator
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+type Server struct {
+	MonotonicHeight int64
+	BlockTime       time.Duration
+	mu              sync.Mutex
+}
+
+type L2State struct {
+	Height    int64
+	StateRoot string
+	Signature []byte
+	TimeStamp time.Time
+	Err       error
+}
+
+func New(blockTime time.Duration, initialHeight int64) *Server {
+	return &Server{
+		MonotonicHeight: initialHeight,
+		BlockTime:       blockTime,
+		mu:              sync.Mutex{},
+	}
+}
+
+func (s *Server) Start(ctx context.Context) {
+	tkr := time.NewTicker(s.BlockTime)
+	go func() {
+		defer tkr.Stop()
+		for {
+			select {
+			case <-tkr.C:
+				s.mu.Lock()
+				s.MonotonicHeight++
+				s.mu.Unlock()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (s *Server) QueryL2() (state L2State) {
+	defer func() {
+		if r := recover(); r != nil {
+			state.Err = fmt.Errorf("panic: %v", r)
+		}
+	}()
+
+	// Simulate Query to L2 and attastation
+	busyLoop := rand.Int63n(20000000000)
+
+	cnt := int64(0)
+	// Simulate Long running attastation Process
+	for range busyLoop {
+		cnt++
+	}
+	if busyLoop < 10000000000 {
+		panic("AAAAAAA")
+	}
+
+	state = L2State{
+		Height:    s.MonotonicHeight,
+		StateRoot: RandString(32),
+		Signature: RandomBytes(64),
+		TimeStamp: time.Now(),
+		Err:       nil,
+	}
+	return state
+}
+
+// letters is the allowed character set for the generated string.
+const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// RandString generates a random string of length n.
+// It is fast but not safe for cryptographic purposes.
+func RandString(n int) string {
+	rand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+// RandomBytes returns a slice of n random bytes using crypto/rand.
+func RandomBytes(n int) []byte {
+	b := make([]byte, n)
+	if _, err := cryptorand.Read(b); err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/spike/eventloop/datastore.go
+++ b/spike/eventloop/datastore.go
@@ -28,7 +28,7 @@ func (h *MinHeap) Pop() interface{} {
 
 func (h *MinHeap) Peak() time.Time {
 	if h.Len() == 0 {
-		return time.Now().Add(time.Duration(time.Now().Year()))
+		return time.Now()
 	}
 	return (*h)[0].TimeStamp
 }

--- a/spike/eventloop/datastore.go
+++ b/spike/eventloop/datastore.go
@@ -1,0 +1,41 @@
+package eventloop
+
+import (
+	"container/heap"
+	"time"
+)
+
+// HeightTs combines a timestamp and a height.
+type HeightTs struct {
+	TimeStamp time.Time
+	Height    int64
+}
+
+// MinHeap implements a min-heap of HeightTs based on TimeStamp.
+type MinHeap []HeightTs
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i].TimeStamp.Before(h[j].TimeStamp) }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.(HeightTs)) }
+func (h *MinHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func (h *MinHeap) Peak() time.Time {
+	if h.Len() == 0 {
+		return time.Now().Add(time.Duration(time.Now().Year()))
+	}
+	return (*h)[0].TimeStamp
+}
+
+// NewMinHeap initializes a heap with the given items.
+func NewMinHeap(items []HeightTs) *MinHeap {
+	h := MinHeap(items)
+	heap.Init(&h)
+	return &h
+}

--- a/spike/eventloop/datastore.go
+++ b/spike/eventloop/datastore.go
@@ -2,7 +2,12 @@ package eventloop
 
 import (
 	"container/heap"
+	"context"
+	"fmt"
+	"slices"
 	"time"
+
+	"github.com/cosmos/solidity-ibc-eureka/attastator"
 )
 
 // HeightTs combines a timestamp and a height.
@@ -38,4 +43,62 @@ func NewMinHeap(items []HeightTs) *MinHeap {
 	h := MinHeap(items)
 	heap.Init(&h)
 	return &h
+}
+
+func (e *EventLoop) DataRotationService(ctx context.Context) {
+	tkr := time.NewTicker(e.DataRotation)
+	go func() {
+		defer tkr.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tkr.C:
+				e.mu.Lock()
+				for ts := e.timeToHeight.Peak(); time.Since(ts) >= e.DataRotation; ts = e.timeToHeight.Peak() {
+					select {
+					case <-ctx.Done():
+						return
+					default:
+					}
+					top := heap.Pop(e.timeToHeight).(HeightTs)
+					recents := make([]attastator.L2State, 0)
+					for _, st := range e.AttastationStorage[top.Height] {
+						if time.Since(st.TimeStamp) >= e.DataRotation {
+							fmt.Printf("Discarding: %s\n", st.StateRoot)
+							continue
+						}
+						recents = append(recents, st)
+					}
+					if len(recents) == 0 {
+						delete(e.AttastationStorage, top.Height)
+					} else {
+						e.AttastationStorage[top.Height] = recents
+					}
+				}
+				e.mu.Unlock()
+			}
+		}
+	}()
+}
+
+// For testing
+func (e *EventLoop) DumpData() []attastator.L2State {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	ret := make([]attastator.L2State, 0)
+	for _, v := range e.AttastationStorage {
+		ret = append(ret, v...)
+	}
+	slices.SortFunc(ret, func(a, b attastator.L2State) int {
+		cmp := a.TimeStamp.Compare(b.TimeStamp)
+		if cmp != 0 {
+			return cmp
+		}
+		if a.Height < b.Height {
+			return -1
+		}
+		return 1
+	})
+	return ret
 }

--- a/spike/eventloop/datastore_test.go
+++ b/spike/eventloop/datastore_test.go
@@ -1,0 +1,94 @@
+package eventloop_test
+
+import (
+	"container/heap"
+	"testing"
+	"time"
+
+	"github.com/cosmos/solidity-ibc-eureka/eventloop"
+)
+
+// Helper to compare two time.Time values exactly
+func timesEqual(a, b time.Time) bool {
+	return a.Equal(b)
+}
+
+func TestNewMinHeapAndPeak(t *testing.T) {
+	// Prepare deterministic timestamps
+	t1 := time.Date(2025, 6, 14, 0, 0, 0, 0, time.UTC) // oldest
+	t2 := time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2025, 6, 16, 0, 0, 0, 0, time.UTC) // newest
+
+	// Unordered input
+	items := []eventloop.HeightTs{
+		{TimeStamp: t3, Height: 3},
+		{TimeStamp: t1, Height: 1},
+		{TimeStamp: t2, Height: 2},
+	}
+
+	h := eventloop.NewMinHeap(items)
+
+	// The earliest timestamp should be at the root
+	peak := h.Peak()
+	if !timesEqual(peak, t1) {
+		t.Errorf("Peak() = %v; want %v", peak, t1)
+	}
+}
+
+func TestPushPopOrder(t *testing.T) {
+	// Prepare deterministic timestamps
+	t1 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	// Start with an empty heap
+	h := eventloop.NewMinHeap(nil)
+
+	// Push in reverse order
+	heap.Push(h, eventloop.HeightTs{TimeStamp: t3, Height: 3})
+	heap.Push(h, eventloop.HeightTs{TimeStamp: t1, Height: 1})
+	heap.Push(h, eventloop.HeightTs{TimeStamp: t2, Height: 2})
+
+	// After pushes, Peak() should give the oldest (t1)
+	if got := h.Peak(); !timesEqual(got, t1) {
+		t.Errorf("After pushes, Peak() = %v; want %v", got, t1)
+	}
+
+	// Pop in order and verify ascending timestamp / height
+	expected := []struct {
+		ts     time.Time
+		height int64
+	}{
+		{t1, 1},
+		{t2, 2},
+		{t3, 3},
+	}
+
+	for i, exp := range expected {
+		x := heap.Pop(h).(eventloop.HeightTs)
+		if !timesEqual(x.TimeStamp, exp.ts) {
+			t.Errorf("Pop #%d: timestamp = %v; want %v", i, x.TimeStamp, exp.ts)
+		}
+		if x.Height != exp.height {
+			t.Errorf("Pop #%d: height = %d; want %d", i, x.Height, exp.height)
+		}
+	}
+
+	// Heap should now be empty
+	if h.Len() != 0 {
+		t.Errorf("Len() after pops = %d; want 0", h.Len())
+	}
+}
+
+func TestPeakEmptyHeap(t *testing.T) {
+	h := eventloop.NewMinHeap(nil)
+
+	// Peak on empty returns time.Now(); we assert it's within a small window
+	before := time.Now()
+	got := h.Peak()
+	after := time.Now()
+
+	if got.Before(before) || got.After(after) {
+		t.Errorf("Peak() on empty = %v; want between %v and %v", got, before, after)
+	}
+}

--- a/spike/eventloop/eventloop.go
+++ b/spike/eventloop/eventloop.go
@@ -1,0 +1,190 @@
+package eventloop
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cosmos/solidity-ibc-eureka/attastator"
+	"github.com/cosmos/solidity-ibc-eureka/monitor"
+)
+
+type EventLoop struct {
+	DataRotation       time.Duration
+	AttastationStorage map[int64]attastator.L2State
+	timeToHeight       *MinHeap
+	mu                 sync.Mutex
+}
+
+func New(rotation time.Duration) *EventLoop {
+	return &EventLoop{
+		DataRotation:       rotation,
+		timeToHeight:       NewMinHeap(nil),
+		mu:                 sync.Mutex{},
+		AttastationStorage: make(map[int64]attastator.L2State),
+	}
+}
+
+func (e *EventLoop) Start(ctx context.Context, attInterval, monitorIntarval time.Duration, attastator *attastator.Server) {
+	e.DataRotationService(ctx)
+	tkrAtt := time.NewTicker(attInterval)
+	tkrMon := time.NewTicker(monitorIntarval)
+
+	go func() {
+		defer tkrAtt.Stop()
+		defer tkrMon.Stop()
+
+	Loop:
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tkrAtt.C:
+				state := attastator.QueryL2()
+				if state.Err != nil {
+					fmt.Printf("Error From Attastator: %v\n", state.Err)
+					continue Loop
+				}
+				e.StoreL2State(state)
+			case <-tkrMon.C:
+				status := monitor.QueryL2()
+				if status != nil {
+					fmt.Printf("Error From Monitor: %v\n", status)
+				}
+			}
+		}
+	}()
+}
+
+func (e *EventLoop) StoreL2State(state attastator.L2State) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.AttastationStorage[state.Height] = state
+	e.timeToHeight.Push(HeightTs{TimeStamp: state.TimeStamp, Height: state.Height})
+}
+
+func (e *EventLoop) DataRotationService(ctx context.Context) {
+	tkr := time.NewTicker(e.DataRotation)
+	go func() {
+		defer tkr.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tkr.C:
+				e.mu.Lock()
+				for ts := e.timeToHeight.Peak(); time.Since(ts) >= e.DataRotation; {
+					top := e.timeToHeight.Pop().(HeightTs)
+					delete(e.AttastationStorage, top.Height)
+				}
+				e.mu.Unlock()
+			}
+		}
+	}()
+}
+
+// func Start(ctx context.Context, attServers []*attastator.Server, workers int) {
+// 	// Start N daemons TODO: Later
+
+// 	eventCh := make(chan AttsEv)
+// 	defer close(eventCh)
+
+// 	go func() {
+// 		for i, a := range attServers {
+// 			i := i
+// 			go func(a *attastator.Server) {
+// 				tkr := time.NewTicker(time.Second * time.Duration(i+1))
+// 				defer tkr.Stop()
+// 				for {
+// 					select {
+// 					case <-ctx.Done():
+// 						return
+// 					case <-tkr.C:
+// 						events := a.Query()
+// 						for _, e := range events {
+// 							select {
+// 							case <-ctx.Done():
+// 								return
+// 							case eventCh <- AttsEv{ID: e.ID, Busy: e.Busy, AttasServerID: a.ID}:
+// 							}
+// 						}
+// 					}
+// 				}
+// 			}(a)
+// 		}
+// 	}()
+// 	for ev := range eventCh {
+// 		fmt.Println(ev.String())
+// 	}
+// }
+
+// func attasEvProcessor(ctx context.Context, pulse time.Duration, eventCh <-chan AttsEv) (<-chan string, <-chan string, <-chan error) {
+// 	id := ctx.Value("id").(string)
+// 	hbCh := make(chan string)
+// 	notiCh := make(chan string)
+// 	errCh := make(chan error)
+// 	go func() {
+// 		defer close(hbCh)
+// 		defer close(notiCh)
+// 		defer close(errCh)
+// 		for {
+// 			select {
+// 			case <-ctx.Done():
+// 				return
+// 			case e, ok := <-eventCh:
+// 				if !ok {
+// 					return
+// 				}
+// 				go func(e AttsEv, errCh chan error) {
+// 					if e.Busy < 0 {
+// 						panic(fmt.Sprintf("Processor: [%s] Panicked on Event: [%d]", id, e.ID))
+// 					}
+// 				}(e, errCh)
+// 			}
+// 		}
+// 	}()
+// 	return hbCh, notiCh, errCh
+// }
+
+// func demon(timeout time.Duration, processor eventProcessor) eventProcessor {
+// 	return func(ctx context.Context, pulse time.Duration, eventCh <-chan AttsEv) (<-chan string, <-chan string, <-chan error) {
+// 		var hbCh <-chan string
+// 		var notiCh <-chan string
+// 		var errCh <-chan error
+
+// 		go func() {
+// 			restart := func(ctx context.Context) context.CancelFunc {
+// 				processorCtx, cancel := context.WithCancel(ctx)
+// 				hbCh, notiCh, errCh = processor(processorCtx, pulse, eventCh)
+// 				return cancel
+// 			}
+
+// 			processCancel := restart(ctx)
+// 			timeoutCh := time.NewTicker(timeout)
+// 			defer timeoutCh.Stop()
+
+// 		loop:
+// 			for {
+// 				timeoutCh.Reset(timeout)
+// 				for {
+// 					select {
+// 					case <-ctx.Done():
+// 						return
+// 					case <-hbCh:
+// 						continue loop
+// 					case <-timeoutCh.C:
+// 						processCancel()
+// 						processCancel = restart(ctx)
+// 					case err := <-errCh:
+// 						fmt.Printf("Handle Error on demon Or move upward. Err: [%s]", err.Error())
+// 					}
+// 				}
+// 			}
+
+// 		}()
+
+// 		return hbCh, notiCh, errCh
+// 	}
+// }

--- a/spike/eventloop/eventloop.go
+++ b/spike/eventloop/eventloop.go
@@ -28,8 +28,7 @@ func New(rotation time.Duration) *EventLoop {
 	}
 }
 
-func (e *EventLoop) Start(ctx context.Context, attInterval, monitorIntarval time.Duration, attastator *attastator.Server) {
-	e.DataRotationService(ctx)
+func (e *EventLoop) Start(ctx context.Context, attInterval, monitorIntarval time.Duration, attastator *attastator.L2Proxy) {
 	tkrAtt := time.NewTicker(attInterval)
 	tkrMon := time.NewTicker(monitorIntarval)
 
@@ -42,9 +41,7 @@ func (e *EventLoop) Start(ctx context.Context, attInterval, monitorIntarval time
 			case <-ctx.Done():
 				return
 			case <-tkrAtt.C:
-				// fmt.Printf("Querying: ")
 				state := attastator.QueryL2()
-				// fmt.Printf("Got back: %s\n", state.StateRoot)
 				if state.Err != nil {
 					fmt.Printf("Error From Attastator: %v\n", state.Err)
 					continue
@@ -64,176 +61,13 @@ func (e *EventLoop) StoreL2State(state attastator.L2State) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// fmt.Printf("Before Data Add: %v\n\n", e.AttastationStorage)
 	e.AttastationStorage[state.Height] = append(e.AttastationStorage[state.Height], state)
 	heap.Push(e.timeToHeight, HeightTs{TimeStamp: state.TimeStamp, Height: state.Height})
 }
 
-func (e *EventLoop) DataRotationService(ctx context.Context) {
-	tkr := time.NewTicker(e.DataRotation)
-	go func() {
-		defer tkr.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-tkr.C:
-				e.mu.Lock()
-				for ts := e.timeToHeight.Peak(); time.Since(ts) >= e.DataRotation; ts = e.timeToHeight.Peak() {
-					select {
-					case <-ctx.Done():
-						return
-					default:
-					}
-					top := heap.Pop(e.timeToHeight).(HeightTs)
-					recents := make([]attastator.L2State, 0)
-					for _, st := range e.AttastationStorage[top.Height] {
-						if time.Since(st.TimeStamp) >= e.DataRotation {
-							fmt.Printf("Discarding: %s\n", st.StateRoot)
-							continue
-						}
-						recents = append(recents, st)
-					}
-					if len(recents) == 0 {
-						delete(e.AttastationStorage, top.Height)
-					} else {
-						e.AttastationStorage[top.Height] = recents
-					}
-				}
-				e.mu.Unlock()
-			}
-		}
-	}()
-}
-
-func (e *EventLoop) L2State(h int64) []attastator.L2State {
+func (e *EventLoop) L2States(h int64) []attastator.L2State {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	ret := slices.Clone(e.AttastationStorage[h])
 	return ret
 }
-
-// For testing
-func (e *EventLoop) DumpData() []attastator.L2State {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	ret := make([]attastator.L2State, 0)
-	for _, v := range e.AttastationStorage {
-		ret = append(ret, v...)
-	}
-	slices.SortFunc(ret, func(a, b attastator.L2State) int {
-		cmp := a.TimeStamp.Compare(b.TimeStamp)
-		if cmp != 0 {
-			return cmp
-		}
-		if a.Height < b.Height {
-			return -1
-		}
-		return 1
-	})
-	return ret
-}
-
-// func Start(ctx context.Context, attServers []*attastator.Server, workers int) {
-// 	// Start N daemons TODO: Later
-
-// 	eventCh := make(chan AttsEv)
-// 	defer close(eventCh)
-
-// 	go func() {
-// 		for i, a := range attServers {
-// 			i := i
-// 			go func(a *attastator.Server) {
-// 				tkr := time.NewTicker(time.Second * time.Duration(i+1))
-// 				defer tkr.Stop()
-// 				for {
-// 					select {
-// 					case <-ctx.Done():
-// 						return
-// 					case <-tkr.C:
-// 						events := a.Query()
-// 						for _, e := range events {
-// 							select {
-// 							case <-ctx.Done():
-// 								return
-// 							case eventCh <- AttsEv{ID: e.ID, Busy: e.Busy, AttasServerID: a.ID}:
-// 							}
-// 						}
-// 					}
-// 				}
-// 			}(a)
-// 		}
-// 	}()
-// 	for ev := range eventCh {
-// 		fmt.Println(ev.String())
-// 	}
-// }
-
-// func attasEvProcessor(ctx context.Context, pulse time.Duration, eventCh <-chan AttsEv) (<-chan string, <-chan string, <-chan error) {
-// 	id := ctx.Value("id").(string)
-// 	hbCh := make(chan string)
-// 	notiCh := make(chan string)
-// 	errCh := make(chan error)
-// 	go func() {
-// 		defer close(hbCh)
-// 		defer close(notiCh)
-// 		defer close(errCh)
-// 		for {
-// 			select {
-// 			case <-ctx.Done():
-// 				return
-// 			case e, ok := <-eventCh:
-// 				if !ok {
-// 					return
-// 				}
-// 				go func(e AttsEv, errCh chan error) {
-// 					if e.Busy < 0 {
-// 						panic(fmt.Sprintf("Processor: [%s] Panicked on Event: [%d]", id, e.ID))
-// 					}
-// 				}(e, errCh)
-// 			}
-// 		}
-// 	}()
-// 	return hbCh, notiCh, errCh
-// }
-
-// func demon(timeout time.Duration, processor eventProcessor) eventProcessor {
-// 	return func(ctx context.Context, pulse time.Duration, eventCh <-chan AttsEv) (<-chan string, <-chan string, <-chan error) {
-// 		var hbCh <-chan string
-// 		var notiCh <-chan string
-// 		var errCh <-chan error
-
-// 		go func() {
-// 			restart := func(ctx context.Context) context.CancelFunc {
-// 				processorCtx, cancel := context.WithCancel(ctx)
-// 				hbCh, notiCh, errCh = processor(processorCtx, pulse, eventCh)
-// 				return cancel
-// 			}
-
-// 			processCancel := restart(ctx)
-// 			timeoutCh := time.NewTicker(timeout)
-// 			defer timeoutCh.Stop()
-
-// 		loop:
-// 			for {
-// 				timeoutCh.Reset(timeout)
-// 				for {
-// 					select {
-// 					case <-ctx.Done():
-// 						return
-// 					case <-hbCh:
-// 						continue loop
-// 					case <-timeoutCh.C:
-// 						processCancel()
-// 						processCancel = restart(ctx)
-// 					case err := <-errCh:
-// 						fmt.Printf("Handle Error on demon Or move upward. Err: [%s]", err.Error())
-// 					}
-// 				}
-// 			}
-
-// 		}()
-
-// 		return hbCh, notiCh, errCh
-// 	}
-// }

--- a/spike/eventloop/eventloop_test.go
+++ b/spike/eventloop/eventloop_test.go
@@ -1,0 +1,47 @@
+package eventloop_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cosmos/solidity-ibc-eureka/attastator"
+	"github.com/cosmos/solidity-ibc-eureka/eventloop"
+)
+
+func TestEventLoop(t *testing.T) {
+	// Careate an event loop with 10 second data retention
+	loop := eventloop.New(time.Second * 10)
+	ctx, cancel := context.WithCancel(t.Context())
+
+	// Simulate an L2 with 4 second block time.
+	att := attastator.New(time.Second*6, 1)
+	att.Start(ctx)
+
+	loop.Start(ctx, time.Second, time.Second*4, att)
+
+	tk := time.After(time.Second * 50)
+	dump := time.NewTicker(time.Second * 4)
+
+Loop:
+	for {
+		select {
+		case <-tk:
+			cancel()
+			break Loop
+		case <-dump.C:
+			allState := loop.DumpData()
+			fmt.Printf("\n-----------------------------\nAll States\n")
+			pretty(t, allState)
+			fmt.Printf("-----------------------------\n\n")
+		}
+	}
+}
+
+func pretty(t *testing.T, data []attastator.L2State) {
+	t.Helper()
+	for _, d := range data {
+		fmt.Printf("Height: %d  Root: %q TimeStamp: %s\n", d.Height, d.StateRoot, d.TimeStamp.String())
+	}
+}

--- a/spike/eventloop/eventloop_test.go
+++ b/spike/eventloop/eventloop_test.go
@@ -20,6 +20,7 @@ func TestEventLoop(t *testing.T) {
 	att.Start(ctx)
 
 	loop.Start(ctx, time.Second, time.Second*4, att)
+	loop.DataRotationService(ctx)
 
 	tk := time.After(time.Second * 50)
 	dump := time.NewTicker(time.Second * 4)
@@ -42,6 +43,6 @@ Loop:
 func pretty(t *testing.T, data []attastator.L2State) {
 	t.Helper()
 	for _, d := range data {
-		fmt.Printf("Height: %d  Root: %q TimeStamp: %s\n", d.Height, d.StateRoot, d.TimeStamp.String())
+		fmt.Printf("Height: %d  Root: %q TimeStamp: %s\n", d.Height, d.StateRoot, d.TimeStamp.Format("15:04:05"))
 	}
 }

--- a/spike/go.mod
+++ b/spike/go.mod
@@ -1,0 +1,3 @@
+module github.com/cosmos/solidity-ibc-eureka
+
+go 1.24.3

--- a/spike/main.go
+++ b/spike/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/cosmos/solidity-ibc-eureka/attastator"
+	"github.com/cosmos/solidity-ibc-eureka/eventloop"
+)
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	blockTime := time.Second * 5
+	attastator := attastator.New(blockTime, 0)
+	attastator.Start(ctx)
+
+	eventLoop := eventloop.New(blockTime * 5)
+	eventLoop.Start(ctx, time.Second, time.Second*3, attastator)
+
+	time.Sleep(time.Second * 20)
+	cancel()
+}

--- a/spike/main.go
+++ b/spike/main.go
@@ -16,6 +16,7 @@ func main() {
 
 	eventLoop := eventloop.New(blockTime * 5)
 	eventLoop.Start(ctx, time.Second, time.Second*3, attastator)
+	eventLoop.DataRotationService(ctx)
 
 	time.Sleep(time.Second * 20)
 	cancel()

--- a/spike/monitor/service.go
+++ b/spike/monitor/service.go
@@ -1,0 +1,17 @@
+package monitor
+
+import (
+	"errors"
+	"math/rand"
+	"time"
+)
+
+func QueryL2() error {
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+	// Simulate query to L2 LOL.
+	time.Sleep(time.Second)
+	if rnd.Int31n(2) == 0 {
+		return errors.New("Error monitoring L2 Full node")
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This is the second implementation of the eventloop in the attastator actor.
This implementation queries the L2 (mocked) instead of receiving events from L2.

closes: IBC-71


<!--

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sp1-contracts to v4.0.0
chore: removed unused variables
e2e: adding e2e tests for ics20
docs: ics27 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Wrote unit and integration tests.
- [ ] Added relevant natspec and `godoc` comments.
- [ ] Provide a [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) to follow the repository standards.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
