### PR TITLE
docs: fix broken link to ethereum-light-client package in README.md

### DIFF
--- a/programs/cw-ics08-wasm-eth/README.md
+++ b/programs/cw-ics08-wasm-eth/README.md
@@ -1,6 +1,6 @@
 # `CosmWasm` ICS-08 Ethereum Light Client
 
-This repository contains a `CosmWasm` implementation of an Ethereum light client, designed for integration with [`ibc-go`](https://github.com/cosmos/ibc-go)'s [`08-wasm`](https://github.com/cosmos/ibc-go/tree/main/modules/light-clients/08-wasm) client wrapper. It manages IBC client and consensus states, delegating all light client-specific logic to the core module in [`packages/ethereum-light-client`](../../packages/ethereum-light-client).
+This repository contains a `CosmWasm` implementation of an Ethereum light client, designed for integration with [`ibc-go`](https://github.com/cosmos/ibc-go)'s [`08-wasm`](https://github.com/cosmos/ibc-go/tree/main/modules/light-clients/08-wasm) client wrapper. It manages IBC client and consensus states, delegating all light client-specific logic to the core module in [`packages/ethereum/light-client`](../../packages/ethereum/light-client).
 
 ## Light Client Functions
 


### PR DESCRIPTION
The package path was incorrectly referenced as packages/ethereum-light-client when it should be packages/ethereum/light-client.