### PR TITLE
fix: correct error message for dummy light client

### DIFF
--- a/e2e/interchaintestv8/e2esuite/light_clients.go
+++ b/e2e/interchaintestv8/e2esuite/light_clients.go
@@ -27,7 +27,7 @@ func (s *TestSuite) getWasmLightClientBinary() *os.File {
 	if s.ethTestnetType == testvalues.EthTestnetTypePoW {
 		s.T().Log("Using dummy Wasm light client for PoW testnet")
 		file, err := wasm.GetWasmDummyLightClient()
-		s.Require().NoError(err, "Failed to get local Wasm light client binary")
+		s.Require().NoError(err, "Failed to get dummy Wasm light client binary")
 		return file
 	}
 


### PR DESCRIPTION
Fix misleading error message in getWasmLightClientBinary() function the function being called in the PoW testnet case..
The error message incorrectly referred to "local Wasm light client binary" 
when the actual function call was GetWasmDummyLightClient().
