### PR TITLE
[ignore] just a test

### DIFF
--- a/packages/ethereum/tree_hash/src/impls.rs
+++ b/packages/ethereum/tree_hash/src/impls.rs
@@ -204,9 +204,7 @@ impl TreeHash for Bytes {
         let leaves = self.len().div_ceil(BYTES_PER_CHUNK);
 
         let mut hasher = MerkleHasher::with_leaves(leaves);
-        for item in self {
-            hasher.write(item.tree_hash_root()[..1].as_ref()).unwrap();
-        }
+        hasher.write(self.as_ref()).unwrap();
 
         mix_in_length(&hasher.finish().unwrap(), self.len())
     }
@@ -229,9 +227,7 @@ impl TreeHash for Bloom {
         let leaves = self.len().div_ceil(BYTES_PER_CHUNK);
 
         let mut hasher = MerkleHasher::with_leaves(leaves);
-        for item in self {
-            hasher.write(item.tree_hash_root()[..1].as_ref()).unwrap();
-        }
+        hasher.write(self.as_ref()).unwrap();
 
         hasher.finish().unwrap()
     }
@@ -251,11 +247,11 @@ impl TreeHash for [B256] {
     }
 
     fn tree_hash_root(&self) -> Hash256 {
-        let leaves = self.len().div_ceil(BYTES_PER_CHUNK);
+        let leaves = self.len();
 
         let mut hasher = MerkleHasher::with_leaves(leaves);
         for item in self {
-            hasher.write(item.tree_hash_root()[..1].as_ref()).unwrap();
+            hasher.write(item.as_slice()).unwrap();
         }
 
         hasher.finish().unwrap()

--- a/packages/ethereum/tree_hash/src/merkle_hasher.rs
+++ b/packages/ethereum/tree_hash/src/merkle_hasher.rs
@@ -199,7 +199,7 @@ impl MerkleHasher {
     /// == 2` can only accept 2 leaves. A tree of `depth == 14` can only accept 8,192 leaves.
     pub fn write(&mut self, bytes: &[u8]) -> Result<(), Error> {
         let mut ptr = 0;
-        while ptr <= bytes.len() {
+        while ptr < bytes.len() {
             let slice = &bytes[ptr..std::cmp::min(bytes.len(), ptr + HASHSIZE)];
 
             if self.buffer.is_empty() && slice.len() == HASHSIZE {
@@ -207,7 +207,7 @@ impl MerkleHasher {
                 ptr += HASHSIZE
             } else if self.buffer.len() + slice.len() < HASHSIZE {
                 self.buffer.extend_from_slice(slice);
-                ptr += HASHSIZE
+                ptr += slice.len()
             } else {
                 let buf_len = self.buffer.len();
                 let required = HASHSIZE - buf_len;

--- a/packages/solidity/src/msgs.rs
+++ b/packages/solidity/src/msgs.rs
@@ -35,7 +35,7 @@ impl ISP1Msgs::SP1Proof {
     /// Panics if the vkey is not a valid hex string, or if the bytes cannot be decoded.
     #[must_use]
     pub fn new(vkey: &str, proof: Vec<u8>, public_values: Vec<u8>) -> Self {
-        let stripped = vkey.strip_prefix("0x").expect("failed to strip prefix");
+        let stripped = vkey.strip_prefix("0x").unwrap_or(vkey);
         let vkey_bytes: [u8; 32] = hex::decode(stripped)
             .expect("failed to decode vkey")
             .try_into()


### PR DESCRIPTION
## Description

This PR addresses three distinct bugs identified in the codebase, improving correctness, performance, and robustness:

1.  **Corrected Tree Hashing Logic**: Fixed incorrect hashing for `Bytes`, `Bloom`, and `[B256]` in `packages/ethereum/tree_hash/src/impls.rs`. Previously, these types were incorrectly hashing only 1-byte slices or treating `[B256]` as a single byte array. The fix ensures full 32-byte chunks are hashed as leaves and lengths are correctly mixed in, preserving entropy and yielding correct Merkle roots.
2.  **MerkleHasher::write Loop and Pointer Fix**: Addressed an off-by-one error in the `while` loop condition and an incorrect pointer increment in `MerkleHasher::write` within `packages/ethereum/tree_hash/src/merkle_hasher.rs`. The original logic could lead to an extra empty iteration and inefficiently skip data. The fix corrects the loop boundary and ensures the pointer advances by the actual slice length.
3.  **Robust vkey Parsing**: Improved the `vkey` parsing in `packages/solidity/src/msgs.rs` to accept inputs with or without the `0x` prefix. Previously, the function would panic if the `0x` prefix was missing, making it less robust to valid hex string inputs.

closes: #XXXX (No specific issue linked, as this was a general bug-finding task)

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work. (N/A - general bug-finding task)
- [ ] Wrote unit and integration tests. (N/A - Environment limitations prevented running/writing tests, but changes are localized and type-consistent.)
- [ ] Added relevant natspec and `godoc` comments. (N/A - No new functions or complex logic requiring additional comments beyond existing ones.)
- [x] Provide a [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) to follow the repository standards.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.

---
<a href="https://cursor.com/background-agent?bcId=bc-99325be3-96ac-4696-82a4-cdb7c4fb500e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99325be3-96ac-4696-82a4-cdb7c4fb500e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

