### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/abigen.yaml
+++ b/.github/workflows/abigen.yaml
@@ -19,7 +19,7 @@ jobs:
   check:
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up environment
         uses: ./.github/actions/foundry-setup
 
@@ -47,7 +47,7 @@ jobs:
   golangci:
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v4
         with:
           go-version: 1.23
@@ -62,7 +62,7 @@ jobs:
   test:
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v4
         with:
           go-version: 1.23

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       registry_url: ghcr.io/cosmos/eureka-relayer
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -42,7 +42,7 @@ jobs:
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Generate Test Matrix
         id: get-matrix
         uses: ./.github/actions/e2e-matrix
@@ -57,7 +57,7 @@ jobs:
     name: ${{ matrix.test }}
     runs-on: depot-ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up E2E environment
         uses: ./.github/actions/e2e-setup
         with:

--- a/.github/workflows/e2e-minimal.yml
+++ b/.github/workflows/e2e-minimal.yml
@@ -43,7 +43,7 @@ jobs:
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Generate Test Matrix
         id: get-matrix
         uses: ./.github/actions/e2e-matrix
@@ -58,7 +58,7 @@ jobs:
     name: ${{ matrix.test }}
     runs-on: depot-ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up E2E environment
         uses: ./.github/actions/e2e-setup
         with:

--- a/.github/workflows/e2e-mock.yml
+++ b/.github/workflows/e2e-mock.yml
@@ -30,7 +30,7 @@ jobs:
     name: lint
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v4
         with:
           go-version: 1.23
@@ -47,7 +47,7 @@ jobs:
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Generate Test Matrix
         id: get-matrix
         uses: ./.github/actions/e2e-matrix
@@ -62,7 +62,7 @@ jobs:
     name: ${{ matrix.test }}
     runs-on: depot-ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up E2E environment
         uses: ./.github/actions/e2e-setup
         with:

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -16,7 +16,7 @@ jobs:
   lint:
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up environment
         uses: ./.github/actions/foundry-setup
 
@@ -35,7 +35,7 @@ jobs:
   build:
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up environment
         uses: ./.github/actions/foundry-setup
 
@@ -51,7 +51,7 @@ jobs:
     needs: [lint, build]
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up environment
         uses: ./.github/actions/foundry-setup
 
@@ -79,7 +79,7 @@ jobs:
     needs: [build]
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up environment
         uses: ./.github/actions/foundry-setup
 
@@ -101,7 +101,7 @@ jobs:
     needs: [test]
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up environment
         uses: ./.github/actions/foundry-setup
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: depot-ubuntu-22.04-4
     if: startsWith(github.ref_name, 'sp1-programs-')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Install SP1 toolchain
@@ -38,7 +38,7 @@ jobs:
     runs-on: depot-ubuntu-22.04-4
     if: startsWith(github.ref_name, 'cw-ics08-wasm-eth-')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Upload cw-ics08-wasm-eth to release
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     name: fmt-and-clippy
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up environment
         uses: ./.github/actions/foundry-setup
 
@@ -36,7 +36,7 @@ jobs:
     name: unit-tests
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up environment
         uses: ./.github/actions/foundry-setup
 
@@ -52,7 +52,7 @@ jobs:
     runs-on: depot-ubuntu-22.04-4
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up environment
         uses: ./.github/actions/foundry-setup
       - name: Build
@@ -66,7 +66,7 @@ jobs:
     runs-on: depot-ubuntu-22.04-4
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up environment
         uses: ./.github/actions/foundry-setup
       - name: Build
@@ -80,7 +80,7 @@ jobs:
     runs-on: depot-ubuntu-22.04-4
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0