### PR TITLE
fix(test): use trusted consensus state timestamp for test timing validation

### DIFF
--- a/packages/tendermint-light-client/uc-and-membership/tests/helpers.rs
+++ b/packages/tendermint-light-client/uc-and-membership/tests/helpers.rs
@@ -200,10 +200,10 @@ pub fn setup_test_context(fixture: UcAndMembershipFixture) -> TestContext {
     let kv_pair = KVPair::from(&fixture.membership_msg);
     let merkle_proof = hex_to_merkle_proof(&fixture.membership_msg.proof);
 
-    let current_time = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
+    let one_hour_nanos: u128 = 3600 * 1_000_000_000;
+
+    let current_time = (trusted_consensus_state.timestamp.unix_timestamp_nanos() as u128)
+        .saturating_add(one_hour_nanos);
 
     TestContext {
         client_state,

--- a/packages/tendermint-light-client/update-client/tests/helpers.rs
+++ b/packages/tendermint-light-client/update-client/tests/helpers.rs
@@ -144,10 +144,10 @@ pub fn setup_test_context(fixture: UpdateClientFixture) -> TestContext {
     let proposed_header = hex_to_header(&fixture.update_client_message.client_message_hex)
         .expect("Failed to parse header from fixture");
 
-    let current_time = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
+    let one_hour_nanos: u128 = 3600 * 1_000_000_000;
+
+    let current_time = (trusted_consensus_state.timestamp.unix_timestamp_nanos() as u128)
+        .saturating_add(one_hour_nanos);
 
     TestContext {
         client_state,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Fixed HeaderVerificationFailed errors in tendermint light client tests by using trusted consensus state timestamp + 1 hour instead of current system time

closes: #XXXX

<!--

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sp1-contracts to v4.0.0
chore: removed unused variables
e2e: adding e2e tests for ics20
docs: ics27 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Wrote unit and integration tests.
- [ ] Added relevant natspec and `godoc` comments.
- [ ] Provide a [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) to follow the repository standards.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
