### PR TITLE
feat(docker): containerize IBC eureka into a single docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,3 +65,49 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
+
+  build-eureka:
+    runs-on: depot-ubuntu-24.04-4
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    env:
+      registry_url: ghcr.io/cosmos/ibc-eureka
+    steps:
+      - uses: actions/checkout@v5
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        env:
+          DOCKER_METADATA_PR_HEAD_SHA: true
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ${{ env.registry_url }}
+          tags: |
+            # Tag triggered events
+            type=match,event=tag,pattern=^relayer-(v[0-9]+\.[0-9]+\.[0-9]+)$,group=1,priority=1000
+
+            # Latest, but only on main
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch' }},priority=900
+
+            # For PR tags
+            type=ref,event=pr,priority=800
+
+            # For sha tags
+            type=sha,priority=700,prefix=
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,7 @@ WORKDIR /src
 
 COPY . .
 
-RUN cargo build --release --locked --bin relayer --bin operator
-
-RUN \
+RUN cargo build --release --locked --bin relayer && \
     cargo build --release --locked --bin ibc_attestor -F op && \
     mv target/release/ibc_attestor target/release/attestor-optimism && \
     cargo build --release --locked --bin ibc_attestor -F arbitrum && \
@@ -34,7 +32,6 @@ COPY scripts/docker/all-in-one-entrypoint.sh /entrypoint.sh
 COPY --from=build /etc/ssl/certs /etc/ssl/certs
 
 COPY --from=build /src/target/release/relayer /usr/local/bin/relayer
-COPY --from=build /src/target/release/operator /usr/local/bin/operator
 
 COPY --from=build /src/target/release/attestor-optimism /usr/local/bin/attestor-optimism
 COPY --from=build /src/target/release/attestor-arbitrum /usr/local/bin/attestor-arbitrum

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Note that NONE of "rust x docker" optimizations are applied to this Dockerfile
+# Because the binaries will be converged & simplified
+# Consider this as v0.1 Dockerfile
+# TODO: cargo chef
+# TODO: sccache
+
+FROM rust:1.89-bookworm AS build
+
+ARG CARGO_TERM_COLOR=always
+ARG RUSTFLAGS="-C codegen-units=8"
+
+RUN apt update && apt install -y build-essential protobuf-compiler ca-certificates
+
+WORKDIR /src
+
+COPY . .
+
+RUN cargo build --release --locked --bin relayer --bin operator
+
+RUN \
+    cargo build --release --locked --bin ibc_attestor -F op && \
+    mv target/release/ibc_attestor target/release/attestor-optimism && \
+    cargo build --release --locked --bin ibc_attestor -F arbitrum && \
+    mv target/release/ibc_attestor target/release/attestor-arbitrum && \
+    cargo build --release --locked --bin ibc_attestor -F cosmos && \
+    mv target/release/ibc_attestor target/release/attestor-cosmos
+
+FROM gcr.io/distroless/cc-debian12:debug
+
+WORKDIR /usr/local/bin
+
+COPY scripts/docker/all-in-one-entrypoint.sh /entrypoint.sh
+
+COPY --from=build /etc/ssl/certs /etc/ssl/certs
+
+COPY --from=build /src/target/release/relayer /usr/local/bin/relayer
+COPY --from=build /src/target/release/operator /usr/local/bin/operator
+
+COPY --from=build /src/target/release/attestor-optimism /usr/local/bin/attestor-optimism
+COPY --from=build /src/target/release/attestor-arbitrum /usr/local/bin/attestor-arbitrum
+COPY --from=build /src/target/release/attestor-cosmos /usr/local/bin/attestor-cosmos
+
+# 3000 is the relayer port
+# 8080 is the attestor port
+EXPOSE 3000 8080
+
+ENTRYPOINT [ "sh", "/entrypoint.sh" ]

--- a/scripts/docker/all-in-one-entrypoint.sh
+++ b/scripts/docker/all-in-one-entrypoint.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+set -e
+
+# Directory where binaries are installed
+BIN_DIR="/usr/local/bin"
+
+print_help() {
+    cat << EOF
+Usage: <COMMAND> [ARGS...]
+
+Commands:
+    help                    Show this help message
+    sh                      Start an interactive shell
+    relayer                 Run the relayer with provided arguments
+    attestor-optimism       Run the optimism attestor with provided arguments
+    attestor-arbitrum       Run the arbitrum attestor with provided arguments
+    attestor-cosmos         Run the cosmos attestor with provided arguments
+
+Examples:
+    docker run --rm ibc-eureka:latest relayer --config config.json
+    docker run --rm ibc-eureka:latest attestor-optimism --help
+    docker run --rm ibc-eureka:latest sh
+
+EOF
+}
+
+if [ $# -eq 0 ]; then
+    echo "Error: No command provided"
+    echo ""
+    print_help
+    exit 1
+fi
+
+COMMAND="$1"
+shift
+
+case "$COMMAND" in
+    help|--help|-h)
+        print_help
+        exit 0
+        ;;
+    sh)
+        exec /busybox/sh
+        ;;
+    relayer)
+        exec "$BIN_DIR/relayer" "$@"
+        ;;
+    attestor-optimism)
+        exec "$BIN_DIR/attestor-optimism" "$@"
+        ;;
+    attestor-arbitrum)
+        exec "$BIN_DIR/attestor-arbitrum" "$@"
+        ;;
+    attestor-cosmos)
+        exec "$BIN_DIR/attestor-cosmos" "$@"
+        ;;
+    *)
+        echo "Error: Unknown command '$COMMAND'"
+        echo ""
+        print_help
+        exit 1
+        ;;
+esac

--- a/scripts/docker/all-in-one-entrypoint.sh
+++ b/scripts/docker/all-in-one-entrypoint.sh
@@ -12,10 +12,10 @@ Usage: <COMMAND> [ARGS...]
 Commands:
     help                    Show this help message
     sh                      Start an interactive shell
-    relayer                 Run the relayer with provided arguments
-    attestor-optimism       Run the optimism attestor with provided arguments
-    attestor-arbitrum       Run the arbitrum attestor with provided arguments
-    attestor-cosmos         Run the cosmos attestor with provided arguments
+    relayer                 Run the relayer with [ARGS...]
+    attestor-optimism       Run the optimism attestor with [ARGS...]
+    attestor-arbitrum       Run the arbitrum attestor with [ARGS...]
+    attestor-cosmos         Run the cosmos attestor with [ARGS...]
 
 Examples:
     docker run --rm ibc-eureka:latest relayer --config config.json


### PR DESCRIPTION
This PR adds a unified Dockerfile that contains everything from the infra side to run Eureka relayers (except SP1 bins)

The image would live under `ghcr.io/cosmos/ibc-eureka` name

```sh
 ▸ ~/Code/solidity-ibc-eureka ▸ git:feat/ibc-docker ✗ ▸ docker run --rm -it ibce:local help
Usage: <COMMAND> [ARGS...]

Commands:
    help                    Show this help message
    sh                      Start an interactive shell
    relayer                 Run the relayer with [ARGS...]
    attestor-optimism       Run the optimism attestor with [ARGS...]
    attestor-arbitrum       Run the arbitrum attestor with [ARGS...]
    attestor-cosmos         Run the cosmos attestor with [ARGS...]

Examples:
    docker run --rm ibc-eureka:latest relayer --config config.json
    docker run --rm ibc-eureka:latest attestor-optimism --help
    docker run --rm ibc-eureka:latest sh
```


closes IBC-239