### PR TITLE
imp: expose grpc-web on a separate port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5060,6 +5060,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
+ "tokio",
  "tonic 0.13.1",
  "tonic-build",
  "tonic-reflection",

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ COPY --from=build /src/target/release/attestor-cosmos /usr/local/bin/attestor-co
 
 # 3000 is the relayer port
 # 9000 is the relayer metrics port
+# 8081 is the relayer grpc web port
 # 8080 is the attestor port
-EXPOSE 3000 9000 8080
+EXPOSE 3000 9000 8081 8080
 
 ENTRYPOINT [ "sh", "/entrypoint.sh" ]

--- a/packages/relayer/core/Cargo.toml
+++ b/packages/relayer/core/Cargo.toml
@@ -18,6 +18,7 @@ serde      = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
 prost      = { workspace = true, default-features = true }
 tower-http = { workspace = true, default-features = true, features = ["cors"] }
+tokio      = { workspace = true, default-features = true, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 tonic-build = { workspace = true, default-features = true }

--- a/packages/relayer/core/src/builder.rs
+++ b/packages/relayer/core/src/builder.rs
@@ -75,9 +75,21 @@ impl RelayerBuilder {
             );
         }
 
-        // Start the gRPC server
-        tracing::info!("Started gRPC server on {}", socket_addr);
-        Server::builder()
+        // Start separate servers for gRPC (HTTP/2) and gRPC-Web (HTTP/1.1)
+        let relayer_service = RelayerServiceServer::new(relayer);
+        let grpc_addr = socket_addr;
+        // TODO: Make grpc-web configurable
+        let web_addr = std::net::SocketAddr::new(grpc_addr.ip(), 8080);
+
+        tracing::info!("Starting gRPC server (HTTP/2) on {}", grpc_addr);
+        tracing::info!("Starting gRPC-Web server (HTTP/1.1) on {}", web_addr);
+
+        let grpc_server = Server::builder()
+            .add_service(relayer_service.clone())
+            .add_service(reflection_service)
+            .serve(grpc_addr);
+
+        let web_server = Server::builder()
             .accept_http1(true)
             .layer(
                 CorsLayer::new()
@@ -86,10 +98,10 @@ impl RelayerBuilder {
                     .allow_headers(Any),
             )
             .layer(GrpcWebLayer::new())
-            .add_service(RelayerServiceServer::new(relayer))
-            .add_service(reflection_service)
-            .serve(socket_addr)
-            .await?;
+            .add_service(relayer_service)
+            .serve(web_addr);
+
+        tokio::try_join!(grpc_server, web_server)?;
 
         Ok(())
     }

--- a/packages/relayer/core/src/builder.rs
+++ b/packages/relayer/core/src/builder.rs
@@ -79,7 +79,7 @@ impl RelayerBuilder {
         let relayer_service = RelayerServiceServer::new(relayer);
         let grpc_addr = socket_addr;
         // TODO: Make grpc-web configurable
-        let web_addr = std::net::SocketAddr::new(grpc_addr.ip(), 8080);
+        let web_addr = std::net::SocketAddr::new(grpc_addr.ip(), 8081);
 
         tracing::info!("Starting gRPC server (HTTP/2) on {}", grpc_addr);
         tracing::info!("Starting gRPC-Web server (HTTP/1.1) on {}", web_addr);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

<!--

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sp1-contracts to v4.0.0
chore: removed unused variables
e2e: adding e2e tests for ics20
docs: ics27 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Wrote unit and integration tests.
- [ ] Added relevant natspec and `godoc` comments.
- [ ] Provide a [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) to follow the repository standards.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
