### PR TITLE
chore: suppress unknown lint clippy warning for manual_is_multiple_of

### DIFF
--- a/packages/ethereum/light-client/src/trie.rs
+++ b/packages/ethereum/light-client/src/trie.rs
@@ -55,13 +55,14 @@ pub fn validate_merkle_branch(
     let mut value = leaf;
     for (i, branch_node) in branch.iter().take(depth).enumerate() {
         let mut hasher = Sha256::new();
+        #[allow(unknown_lints, clippy::manual_is_multiple_of)]
         // TODO: replace when <https://github.com/CosmWasm/cosmwasm/issues/2485> is resolved
-        if (index / 2u64.checked_pow(u32::try_from(i).unwrap()).unwrap()).is_multiple_of(2) {
-            hasher.update(value);
+        if (index / 2u64.checked_pow(u32::try_from(i).unwrap()).unwrap()) % 2 != 0 {
             hasher.update(branch_node);
+            hasher.update(value);
         } else {
-            hasher.update(branch_node);
             hasher.update(value);
+            hasher.update(branch_node);
         }
         value = B256::from_slice(&hasher.finalize()[..]);
     }

--- a/packages/ethereum/tree_hash/src/merkle_hasher.rs
+++ b/packages/ethereum/tree_hash/src/merkle_hasher.rs
@@ -238,13 +238,14 @@ impl MerkleHasher {
 
         let max_leaves = 1 << (self.depth + 1);
 
+        #[allow(unknown_lints, clippy::manual_is_multiple_of)]
         // TODO: replace when <https://github.com/CosmWasm/cosmwasm/issues/2485> is resolved
         if self.next_leaf > max_leaves {
             return Err(Error::MaximumLeavesExceeded { max_leaves });
         } else if self.next_leaf == 1 {
             // A tree of depth one has a root that is equal to the first given leaf.
             self.root = Some(Hash256::from_slice(leaf))
-        } else if self.next_leaf.is_multiple_of(2) {
+        } else if self.next_leaf % 2 == 0 {
             self.process_left_node(self.next_leaf, Preimage::Slice(leaf))
         } else {
             self.process_right_node(self.next_leaf, Preimage::Slice(leaf))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Fixed clippy issue with `manual_is_multiple_of` lint:

  1. CI was failing with `unknown lint: clippy::manual_is_multiple_of`
  2. Tried removing the `#[allow]` → clippy complained we should use `.is_multiple_of()`
  3. Tried using `.is_multiple_of()` → build failed because it's unstable for unsigned types
  4. Solution: Changed `#[allow(clippy::manual_is_multiple_of)]` to `#[allow(unknown_lints, clippy::manual_is_multiple_of)]`

<!--

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sp1-contracts to v4.0.0
chore: removed unused variables
e2e: adding e2e tests for ics20
docs: ics27 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Wrote unit and integration tests.
- [ ] Added relevant natspec and `godoc` comments.
- [ ] Provide a [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) to follow the repository standards.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
