### PR TITLE
chore(solana): nix pull apple sdk 15

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,8 @@
               go
               gopls
               gofumpt
+            ] ++ lib.optionals stdenv.isDarwin [
+              apple-sdk_15
             ];
             shellHook = ''
               export RUST_SRC_PATH="${rust}/lib/rustlib/src/rust/library"
@@ -112,7 +114,7 @@
               # - libcxx uses SDK 15.5 (linked into binaries)
               # - rust toolchain tries to use SDK 12.3 (sets DEVELOPER_DIR_FOR_TARGET)
               # This causes "Multiple conflicting values defined for DEVELOPER_DIR" linker errors.
-              # We unset the conflicting *_FOR_TARGET variables to force everything to use SDK 11.3.
+              # We unset the conflicting *_FOR_TARGET variables to force everything to use installed apple-sdk_15.
               # Remove this workaround when nixpkgs fixes the SDK version mismatch upstream.
               if [[ "$OSTYPE" == "darwin"* ]]; then
                 unset DEVELOPER_DIR_FOR_TARGET


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Pull in apple sdk 15 for nix due to golang 1.25 requiring 12+ for `SecTrustCopyCertificateChain` API 

<!--

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sp1-contracts to v4.0.0
chore: removed unused variables
e2e: adding e2e tests for ics20
docs: ics27 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Wrote unit and integration tests.
- [ ] Added relevant natspec and `godoc` comments.
- [ ] Provide a [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) to follow the repository standards.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
