### PR TITLE
fix(utils/rpc): reject non-zero ABCI codes in abci queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5819,300 +5819,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proof-api"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "clap",
- "proof-api-core",
- "proof-api-cosmos-to-cosmos",
- "proof-api-cosmos-to-eth",
- "proof-api-cosmos-to-solana",
- "proof-api-eth-to-cosmos",
- "proof-api-eth-to-eth",
- "proof-api-eth-to-solana",
- "proof-api-solana-to-cosmos",
- "proof-api-solana-to-eth",
- "opentelemetry 0.30.0",
- "opentelemetry-appender-tracing",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
- "prometheus",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-log",
- "tracing-opentelemetry",
- "tracing-subscriber",
- "uuid",
- "warp",
-]
-
-[[package]]
-name = "proof-api-core"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "proof-api-lib",
- "prometheus",
- "prost",
- "serde",
- "serde_json",
- "tonic 0.13.1",
- "tonic-build 0.13.1",
- "tonic-reflection",
- "tracing",
-]
-
-[[package]]
-name = "proof-api-cosmos-to-cosmos"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "ibc-core-host-types",
- "proof-api-core",
- "proof-api-lib",
- "ibc-eureka-utils",
- "ibc-proto 0.52.0",
- "ics23",
- "prost",
- "serde",
- "serde_json",
- "tendermint",
- "tendermint-rpc",
- "tonic 0.13.1",
- "tracing",
-]
-
-[[package]]
-name = "proof-api-cosmos-to-eth"
-version = "0.1.0"
-dependencies = [
- "alloy",
- "anyhow",
- "async-trait",
- "ibc-core-host-types",
- "proof-api-core",
- "proof-api-lib",
- "ibc-eureka-solidity-types 0.1.0",
- "ibc-eureka-utils",
- "serde",
- "serde_json",
- "sp1-ics07-tendermint-prover",
- "sp1-sdk",
- "tendermint",
- "tendermint-rpc",
- "tonic 0.13.1",
- "tracing",
-]
-
-[[package]]
-name = "proof-api-cosmos-to-solana"
-version = "0.1.0"
-dependencies = [
- "alloy",
- "anchor-client",
- "anchor-lang",
- "anyhow",
- "base64 0.22.1",
- "bincode",
- "borsh 0.10.4",
- "ed25519-consensus",
- "hex",
- "ibc-client-tendermint",
- "ibc-core-client-types",
- "proof-api-core",
- "proof-api-lib",
- "ibc-eureka-solidity-types 0.1.0",
- "ibc-eureka-utils",
- "ibc-proto 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ibc-proto 0.52.0",
- "prost",
- "serde",
- "serde_json",
- "solana-client",
- "solana-ibc-borsh-header",
- "solana-ibc-constants",
- "solana-ibc-gmp-types",
- "solana-ibc-proto",
- "solana-ibc-sdk",
- "solana-sdk",
- "solana-transaction-status",
- "spl-associated-token-account",
- "spl-token",
- "tendermint",
- "tendermint-proto",
- "tendermint-rpc",
- "tokio",
- "tonic 0.13.1",
- "tracing",
-]
-
-[[package]]
-name = "proof-api-eth-to-cosmos"
-version = "0.1.0"
-dependencies = [
- "alloy",
- "anyhow",
- "async-trait",
- "ethereum-apis",
- "ethereum-light-client 0.1.0",
- "ethereum-types 0.1.0",
- "proof-api-core",
- "proof-api-lib",
- "ibc-eureka-solidity-types 0.1.0",
- "ibc-eureka-utils",
- "ibc-proto 0.52.0",
- "prost",
- "serde",
- "serde_json",
- "tendermint",
- "tendermint-rpc",
- "tonic 0.13.1",
- "tracing",
-]
-
-[[package]]
-name = "proof-api-eth-to-eth"
-version = "0.1.0"
-dependencies = [
- "alloy",
- "anyhow",
- "async-trait",
- "proof-api-core",
- "proof-api-lib",
- "ibc-eureka-solidity-types 0.1.0",
- "serde",
- "serde_json",
- "tonic 0.13.1",
- "tracing",
-]
-
-[[package]]
-name = "proof-api-eth-to-solana"
-version = "0.1.0"
-dependencies = [
- "alloy",
- "anchor-lang",
- "anyhow",
- "bincode",
- "borsh 1.6.1",
- "proof-api-core",
- "proof-api-lib",
- "ibc-eureka-solidity-types 0.1.0",
- "ibc-eureka-utils",
- "ibc-proto 0.52.0",
- "prost",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "solana-client",
- "solana-ibc-constants",
- "solana-ibc-gmp-types",
- "solana-ibc-proto",
- "solana-ibc-sdk",
- "solana-sdk",
- "solana-transaction-status",
- "spl-associated-token-account",
- "spl-token",
- "tonic 0.13.1",
- "tracing",
-]
-
-[[package]]
-name = "proof-api-lib"
-version = "0.1.0"
-dependencies = [
- "alloy",
- "anchor-lang",
- "anyhow",
- "async-trait",
- "base64 0.22.1",
- "bincode",
- "borsh 1.6.1",
- "ethereum-apis",
- "ethereum-light-client 0.1.0",
- "ethereum-types 0.1.0",
- "futures",
- "futures-timer",
- "ibc-client-tendermint-types",
- "ibc-core-commitment-types",
- "ibc-eureka-solidity-types 0.1.0",
- "ibc-eureka-utils",
- "ibc-proto 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ibc-proto 0.52.0",
- "ics23",
- "moka",
- "opentelemetry 0.30.0",
- "prost",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "solana-client",
- "solana-ibc-constants",
- "solana-ibc-gmp-types",
- "solana-ibc-proto",
- "solana-ibc-sdk",
- "solana-sdk",
- "solana-transaction-status",
- "sp1-ics07-tendermint-prover",
- "sp1-sdk",
- "tendermint",
- "tendermint-light-client-verifier",
- "tendermint-rpc",
- "thiserror 2.0.18",
- "tokio",
- "tonic 0.13.1",
- "tonic-build 0.13.1",
- "tracing",
- "tracing-opentelemetry",
-]
-
-[[package]]
-name = "proof-api-solana-to-cosmos"
-version = "0.1.0"
-dependencies = [
- "anchor-client",
- "anchor-lang",
- "anyhow",
- "async-trait",
- "base64 0.22.1",
- "borsh 1.6.1",
- "hex",
- "proof-api-core",
- "proof-api-lib",
- "ibc-eureka-utils",
- "ibc-proto 0.52.0",
- "prost",
- "serde",
- "serde_json",
- "solana-client",
- "solana-sdk",
- "solana-transaction-status",
- "tendermint",
- "tendermint-rpc",
- "tokio",
- "tonic 0.13.1",
- "tracing",
-]
-
-[[package]]
-name = "proof-api-solana-to-eth"
-version = "0.1.0"
-dependencies = [
- "alloy",
- "anyhow",
- "proof-api-core",
- "proof-api-lib",
- "serde",
- "serde_json",
- "solana-sdk",
- "tonic 0.13.1",
- "tracing",
-]
-
-[[package]]
 name = "ibc-eureka-solidity-types"
 version = "0.1.0"
 dependencies = [
@@ -8237,6 +7943,300 @@ dependencies = [
  "parking_lot",
  "protobuf",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "proof-api"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "opentelemetry 0.30.0",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "prometheus",
+ "proof-api-core",
+ "proof-api-cosmos-to-cosmos",
+ "proof-api-cosmos-to-eth",
+ "proof-api-cosmos-to-solana",
+ "proof-api-eth-to-cosmos",
+ "proof-api-eth-to-eth",
+ "proof-api-eth-to-solana",
+ "proof-api-solana-to-cosmos",
+ "proof-api-solana-to-eth",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-log",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+ "uuid",
+ "warp",
+]
+
+[[package]]
+name = "proof-api-core"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "prometheus",
+ "proof-api-lib",
+ "prost",
+ "serde",
+ "serde_json",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
+ "tonic-reflection",
+ "tracing",
+]
+
+[[package]]
+name = "proof-api-cosmos-to-cosmos"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "ibc-core-host-types",
+ "ibc-eureka-utils",
+ "ibc-proto 0.52.0",
+ "ics23",
+ "proof-api-core",
+ "proof-api-lib",
+ "prost",
+ "serde",
+ "serde_json",
+ "tendermint",
+ "tendermint-rpc",
+ "tonic 0.13.1",
+ "tracing",
+]
+
+[[package]]
+name = "proof-api-cosmos-to-eth"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "anyhow",
+ "async-trait",
+ "ibc-core-host-types",
+ "ibc-eureka-solidity-types 0.1.0",
+ "ibc-eureka-utils",
+ "proof-api-core",
+ "proof-api-lib",
+ "serde",
+ "serde_json",
+ "sp1-ics07-tendermint-prover",
+ "sp1-sdk",
+ "tendermint",
+ "tendermint-rpc",
+ "tonic 0.13.1",
+ "tracing",
+]
+
+[[package]]
+name = "proof-api-cosmos-to-solana"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "anchor-client",
+ "anchor-lang",
+ "anyhow",
+ "base64 0.22.1",
+ "bincode",
+ "borsh 0.10.4",
+ "ed25519-consensus",
+ "hex",
+ "ibc-client-tendermint",
+ "ibc-core-client-types",
+ "ibc-eureka-solidity-types 0.1.0",
+ "ibc-eureka-utils",
+ "ibc-proto 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ibc-proto 0.52.0",
+ "proof-api-core",
+ "proof-api-lib",
+ "prost",
+ "serde",
+ "serde_json",
+ "solana-client",
+ "solana-ibc-borsh-header",
+ "solana-ibc-constants",
+ "solana-ibc-gmp-types",
+ "solana-ibc-proto",
+ "solana-ibc-sdk",
+ "solana-sdk",
+ "solana-transaction-status",
+ "spl-associated-token-account",
+ "spl-token",
+ "tendermint",
+ "tendermint-proto",
+ "tendermint-rpc",
+ "tokio",
+ "tonic 0.13.1",
+ "tracing",
+]
+
+[[package]]
+name = "proof-api-eth-to-cosmos"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "anyhow",
+ "async-trait",
+ "ethereum-apis",
+ "ethereum-light-client 0.1.0",
+ "ethereum-types 0.1.0",
+ "ibc-eureka-solidity-types 0.1.0",
+ "ibc-eureka-utils",
+ "ibc-proto 0.52.0",
+ "proof-api-core",
+ "proof-api-lib",
+ "prost",
+ "serde",
+ "serde_json",
+ "tendermint",
+ "tendermint-rpc",
+ "tonic 0.13.1",
+ "tracing",
+]
+
+[[package]]
+name = "proof-api-eth-to-eth"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "anyhow",
+ "async-trait",
+ "ibc-eureka-solidity-types 0.1.0",
+ "proof-api-core",
+ "proof-api-lib",
+ "serde",
+ "serde_json",
+ "tonic 0.13.1",
+ "tracing",
+]
+
+[[package]]
+name = "proof-api-eth-to-solana"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "anchor-lang",
+ "anyhow",
+ "bincode",
+ "borsh 1.6.1",
+ "ibc-eureka-solidity-types 0.1.0",
+ "ibc-eureka-utils",
+ "ibc-proto 0.52.0",
+ "proof-api-core",
+ "proof-api-lib",
+ "prost",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "solana-client",
+ "solana-ibc-constants",
+ "solana-ibc-gmp-types",
+ "solana-ibc-proto",
+ "solana-ibc-sdk",
+ "solana-sdk",
+ "solana-transaction-status",
+ "spl-associated-token-account",
+ "spl-token",
+ "tonic 0.13.1",
+ "tracing",
+]
+
+[[package]]
+name = "proof-api-lib"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "anchor-lang",
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "bincode",
+ "borsh 1.6.1",
+ "ethereum-apis",
+ "ethereum-light-client 0.1.0",
+ "ethereum-types 0.1.0",
+ "futures",
+ "futures-timer",
+ "ibc-client-tendermint-types",
+ "ibc-core-commitment-types",
+ "ibc-eureka-solidity-types 0.1.0",
+ "ibc-eureka-utils",
+ "ibc-proto 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ibc-proto 0.52.0",
+ "ics23",
+ "moka",
+ "opentelemetry 0.30.0",
+ "prost",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "solana-client",
+ "solana-ibc-constants",
+ "solana-ibc-gmp-types",
+ "solana-ibc-proto",
+ "solana-ibc-sdk",
+ "solana-sdk",
+ "solana-transaction-status",
+ "sp1-ics07-tendermint-prover",
+ "sp1-sdk",
+ "tendermint",
+ "tendermint-light-client-verifier",
+ "tendermint-rpc",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
+ "tracing",
+ "tracing-opentelemetry",
+]
+
+[[package]]
+name = "proof-api-solana-to-cosmos"
+version = "0.1.0"
+dependencies = [
+ "anchor-client",
+ "anchor-lang",
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "borsh 1.6.1",
+ "hex",
+ "ibc-eureka-utils",
+ "ibc-proto 0.52.0",
+ "proof-api-core",
+ "proof-api-lib",
+ "prost",
+ "serde",
+ "serde_json",
+ "solana-client",
+ "solana-sdk",
+ "solana-transaction-status",
+ "tendermint",
+ "tendermint-rpc",
+ "tokio",
+ "tonic 0.13.1",
+ "tracing",
+]
+
+[[package]]
+name = "proof-api-solana-to-eth"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "anyhow",
+ "proof-api-core",
+ "proof-api-lib",
+ "serde",
+ "serde_json",
+ "solana-sdk",
+ "tonic 0.13.1",
+ "tracing",
 ]
 
 [[package]]

--- a/packages/utils/src/rpc.rs
+++ b/packages/utils/src/rpc.rs
@@ -259,6 +259,14 @@ impl TendermintRpcExt for HttpClient {
             )
             .await?;
 
+        if res.code.is_err() {
+            anyhow::bail!(
+                "ABCI /ibc.core.channel.v2.Query/PacketCommitment returned non-zero code {}: {}",
+                res.code.value(),
+                res.log,
+            );
+        }
+
         // V1 & V2 share the same response type
         QueryPacketCommitmentResponse::decode(res.value.as_slice())
             .map_err(|e| anyhow::anyhow!("Failed to decode QueryPacketCommitmentResponse: {e}"))
@@ -285,6 +293,14 @@ impl TendermintRpcExt for HttpClient {
             )
             .await?;
 
+        if res.code.is_err() {
+            anyhow::bail!(
+                "ABCI /ibc.core.channel.v2.Query/PacketReceipt returned non-zero code {}: {}",
+                res.code.value(),
+                res.log,
+            );
+        }
+
         QueryPacketReceiptResponse::decode(res.value.as_slice())
             .map_err(|e| anyhow::anyhow!("Failed to decode QueryPacketReceiptResponse: {e}"))
     }
@@ -309,6 +325,14 @@ impl TendermintRpcExt for HttpClient {
                 false,
             )
             .await?;
+
+        if res.code.is_err() {
+            anyhow::bail!(
+                "ABCI /ibc.core.channel.v2.Query/PacketAcknowledgement returned non-zero code {}: {}",
+                res.code.value(),
+                res.log,
+            );
+        }
 
         QueryPacketAcknowledgementResponse::decode(res.value.as_slice()).map_err(|e| {
             anyhow::anyhow!("Failed to decode QueryPacketAcknowledgementResponse: {e}")

--- a/packages/utils/src/rpc.rs
+++ b/packages/utils/src/rpc.rs
@@ -158,7 +158,7 @@ impl TendermintRpcExt for HttpClient {
     }
 
     async fn sdk_staking_params(&self) -> Result<Params> {
-        let abci_resp = self
+        let res = self
             .abci_query(
                 Some("/cosmos.staking.v1beta1.Query/Params".to_string()),
                 QueryParamsRequest::default().to_bytes()?,
@@ -166,13 +166,22 @@ impl TendermintRpcExt for HttpClient {
                 false,
             )
             .await?;
-        QueryParamsResponse::decode(abci_resp.value.as_slice())?
+
+        if res.code.is_err() {
+            anyhow::bail!(
+                "ABCI /cosmos.staking.v1beta1.Query/Params returned non-zero code {}: {}",
+                res.code.value(),
+                res.log,
+            );
+        }
+
+        QueryParamsResponse::decode(res.value.as_slice())?
             .params
             .ok_or_else(|| anyhow::anyhow!("No staking params found"))
     }
 
     async fn client_state(&self, client_id: String) -> Result<Any> {
-        let abci_resp = self
+        let res = self
             .abci_query(
                 Some("/ibc.core.client.v1.Query/ClientState".to_string()),
                 QueryClientStateRequest { client_id }.to_bytes()?,
@@ -181,13 +190,21 @@ impl TendermintRpcExt for HttpClient {
             )
             .await?;
 
-        QueryClientStateResponse::decode(abci_resp.value.as_slice())?
+        if res.code.is_err() {
+            anyhow::bail!(
+                "ABCI /ibc.core.client.v1.Query/ClientState returned non-zero code {}: {}",
+                res.code.value(),
+                res.log,
+            );
+        }
+
+        QueryClientStateResponse::decode(res.value.as_slice())?
             .client_state
             .ok_or_else(|| anyhow::anyhow!("No client state found"))
     }
 
     async fn consensus_state(&self, client_id: String, revision_height: u64) -> Result<Any> {
-        let abci_resp = self
+        let res = self
             .abci_query(
                 Some("/ibc.core.client.v1.Query/ConsensusState".to_string()),
                 QueryConsensusStateRequest {
@@ -202,7 +219,15 @@ impl TendermintRpcExt for HttpClient {
             )
             .await?;
 
-        QueryConsensusStateResponse::decode(abci_resp.value.as_slice())?
+        if res.code.is_err() {
+            anyhow::bail!(
+                "ABCI /ibc.core.client.v1.Query/ConsensusState returned non-zero code {}: {}",
+                res.code.value(),
+                res.log,
+            );
+        }
+
+        QueryConsensusStateResponse::decode(res.value.as_slice())?
             .consensus_state
             .ok_or_else(|| anyhow::anyhow!("No consensus state found"))
     }
@@ -217,6 +242,15 @@ impl TendermintRpcExt for HttpClient {
                 true,
             )
             .await?;
+
+        if res.code.is_err() {
+            anyhow::bail!(
+                "ABCI store/{} query returned non-zero code {}: {}",
+                std::str::from_utf8(&path[0])?,
+                res.code.value(),
+                res.log,
+            );
+        }
 
         if res.height.value() + 1 != height {
             anyhow::bail!("Proof height mismatch");


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

The packet query helpers this PR touches decode abci_query responses without
inspecting the ABCI application code. When the application code is non-zero `res.value` is an empty slice. Decoding this results in defaulting to the zero value, `received: false`. This is incorrect as the attest for example will interpret this as a valid response indicating a packet has not been received and it can lead to the incorrect generation of non-membership attestations.


<!--

This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Example commit messages:

fix: skip emission of unpopulated memo field in ics20
deps: updating sp1-contracts to v4.0.0
chore: removed unused variables
e2e: adding e2e tests for ics20
docs: ics27 documentation updates
feat: add semantic version utilities for e2e tests
feat(api)!: this is an api breaking feature
fix(statemachine)!: this is a statemachine breaking fix
-->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Wrote unit and integration tests.
- [ ] Added relevant natspec and `godoc` comments.
- [ ] Provide a [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) to follow the repository standards.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Review `SonarCloud Report` in the comment section below once CI passes.
