### PR TITLE
imp(solidity/IBCRolesLib): added missing role selectors

### DIFF
--- a/contracts/utils/IBCRolesLib.sol
+++ b/contracts/utils/IBCRolesLib.sol
@@ -58,6 +58,15 @@ library IBCRolesLib {
         return idCustomizerFunctions;
     }
 
+    /// @notice The functions that can be used to migrate clients in ICS26Router.
+    /// @dev These functions are not associated with a specific role, but are restricted to the ADMIN_ROLE.
+    /// @return An array of function selectors that can be used to migrate clients.
+    function ics26MigrationSelectors() internal pure returns (bytes4[] memory) {
+        bytes4[] memory migrationFunctions = new bytes4[](1);
+        migrationFunctions[0] = IICS02ClientAccessControlled.migrateClient.selector;
+        return migrationFunctions;
+    }
+
     /// @notice The functions that can be called by the ERC20_CUSTOMIZER_ROLE in ICS20Transfer.
     /// @return An array of function selectors that can be called by the ERC20_CUSTOMIZER_ROLE.
     function erc20CustomizerSelectors() internal pure returns (bytes4[] memory) {

--- a/contracts/utils/IBCRolesLib.sol
+++ b/contracts/utils/IBCRolesLib.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 import { IICS26RouterAccessControlled } from "../interfaces/IICS26Router.sol";
 import { IICS02ClientAccessControlled } from "../interfaces/IICS02Client.sol";
 import { IICS20TransferAccessControlled } from "../interfaces/IICS20Transfer.sol";
+import { IICS27GMP } from "../interfaces/IICS27GMP.sol";
 import { IPausable } from "../interfaces/IPausable.sol";
 import { IRateLimit } from "../interfaces/IRateLimit.sol";
 import { UUPSUpgradeable } from "@openzeppelin-contracts/proxy/utils/UUPSUpgradeable.sol";
@@ -61,7 +62,7 @@ library IBCRolesLib {
     /// @notice The functions that can be used to migrate clients in ICS26Router.
     /// @dev These functions are not associated with a specific role, but are restricted to the ADMIN_ROLE.
     /// @return An array of function selectors that can be used to migrate clients.
-    function ics26MigrationSelectors() internal pure returns (bytes4[] memory) {
+    function ics26ClientMigrationSelectors() internal pure returns (bytes4[] memory) {
         bytes4[] memory migrationFunctions = new bytes4[](1);
         migrationFunctions[0] = IICS02ClientAccessControlled.migrateClient.selector;
         return migrationFunctions;
@@ -110,10 +111,19 @@ library IBCRolesLib {
     /// @notice The functions that can be used to upgrade the beacon contracts in ICS20Transfer.
     /// @dev These functions are not associated with a specific role, but are restricted to the ADMIN_ROLE.
     /// @return An array of function selectors that can be used to upgrade the beacon contracts.
-    function beaconUpgradeSelectors() internal pure returns (bytes4[] memory) {
+    function ics20BeaconUpgradeSelectors() internal pure returns (bytes4[] memory) {
         bytes4[] memory beaconUpgradeFunctions = new bytes4[](2);
         beaconUpgradeFunctions[0] = IICS20TransferAccessControlled.upgradeEscrowTo.selector;
         beaconUpgradeFunctions[1] = IICS20TransferAccessControlled.upgradeIBCERC20To.selector;
+        return beaconUpgradeFunctions;
+    }
+
+    /// @notice The functions that can be used to upgrade the beacon contracts in ICS27GMP.
+    /// @dev These functions are not associated with a specific role, but are restricted to the ADMIN_ROLE.
+    /// @return An array of function selectors that can be used to upgrade the beacon contracts.
+    function ics27BeaconUpgradeSelectors() internal pure returns (bytes4[] memory) {
+        bytes4[] memory beaconUpgradeFunctions = new bytes4[](1);
+        beaconUpgradeFunctions[0] = IICS27GMP.upgradeAccountTo.selector;
         return beaconUpgradeFunctions;
     }
 

--- a/scripts/deployments/DeployAccessManagerWithRoles.sol
+++ b/scripts/deployments/DeployAccessManagerWithRoles.sol
@@ -32,8 +32,7 @@ abstract contract DeployAccessManagerWithRoles {
         accessManager.setTargetFunctionRole(ics27Gmp, IBCRolesLib.unpauserSelectors(), IBCRolesLib.UNPAUSER_ROLE);
         // TODO: fix rate limiter role (#559)
 
-        // Add admin role for upgradeable contracts
-        // This is actually a no-op since if no role is set, the admin role is assumed
+        // Explicitly register admin-gated selectors so deployments expose the full role map.
         accessManager.setTargetFunctionRole(ics26, IBCRolesLib.ics26MigrationSelectors(), IBCRolesLib.ADMIN_ROLE);
         accessManager.setTargetFunctionRole(ics20, IBCRolesLib.beaconUpgradeSelectors(), IBCRolesLib.ADMIN_ROLE);
         accessManager.setTargetFunctionRole(ics20, IBCRolesLib.uupsUpgradeSelectors(), IBCRolesLib.ADMIN_ROLE);

--- a/scripts/deployments/DeployAccessManagerWithRoles.sol
+++ b/scripts/deployments/DeployAccessManagerWithRoles.sol
@@ -33,8 +33,9 @@ abstract contract DeployAccessManagerWithRoles {
         // TODO: fix rate limiter role (#559)
 
         // Explicitly register admin-gated selectors so deployments expose the full role map.
-        accessManager.setTargetFunctionRole(ics26, IBCRolesLib.ics26MigrationSelectors(), IBCRolesLib.ADMIN_ROLE);
-        accessManager.setTargetFunctionRole(ics20, IBCRolesLib.beaconUpgradeSelectors(), IBCRolesLib.ADMIN_ROLE);
+        accessManager.setTargetFunctionRole(ics26, IBCRolesLib.ics26ClientMigrationSelectors(), IBCRolesLib.ADMIN_ROLE);
+        accessManager.setTargetFunctionRole(ics20, IBCRolesLib.ics20BeaconUpgradeSelectors(), IBCRolesLib.ADMIN_ROLE);
+        accessManager.setTargetFunctionRole(ics27Gmp, IBCRolesLib.ics27BeaconUpgradeSelectors(), IBCRolesLib.ADMIN_ROLE);
         accessManager.setTargetFunctionRole(ics20, IBCRolesLib.uupsUpgradeSelectors(), IBCRolesLib.ADMIN_ROLE);
         accessManager.setTargetFunctionRole(ics26, IBCRolesLib.uupsUpgradeSelectors(), IBCRolesLib.ADMIN_ROLE);
         accessManager.setTargetFunctionRole(ics27Gmp, IBCRolesLib.uupsUpgradeSelectors(), IBCRolesLib.ADMIN_ROLE);

--- a/scripts/deployments/DeployAccessManagerWithRoles.sol
+++ b/scripts/deployments/DeployAccessManagerWithRoles.sol
@@ -34,6 +34,7 @@ abstract contract DeployAccessManagerWithRoles {
 
         // Add admin role for upgradeable contracts
         // This is actually a no-op since if no role is set, the admin role is assumed
+        accessManager.setTargetFunctionRole(ics26, IBCRolesLib.ics26MigrationSelectors(), IBCRolesLib.ADMIN_ROLE);
         accessManager.setTargetFunctionRole(ics20, IBCRolesLib.beaconUpgradeSelectors(), IBCRolesLib.ADMIN_ROLE);
         accessManager.setTargetFunctionRole(ics20, IBCRolesLib.uupsUpgradeSelectors(), IBCRolesLib.ADMIN_ROLE);
         accessManager.setTargetFunctionRole(ics26, IBCRolesLib.uupsUpgradeSelectors(), IBCRolesLib.ADMIN_ROLE);

--- a/test/shadowfork/MainnetForkTest.t.sol
+++ b/test/shadowfork/MainnetForkTest.t.sol
@@ -18,7 +18,7 @@ import { DeployAccessManagerWithRoles } from "../../scripts/deployments/DeployAc
 
 contract MainnetForkTest is Test, DeployAccessManagerWithRoles {
     // solhint-disable-next-line var-name-mixedcase
-    string public ETH_RPC_URL = vm.envString("ETH_RPC_URL");
+    string public ETH_RPC_URL;
 
     string public clientId = "cosmoshub-0";
 
@@ -30,6 +30,9 @@ contract MainnetForkTest is Test, DeployAccessManagerWithRoles {
     address public relayer = 0xC4C09A23dDBd1fF0f313885265113F83622284C2;
 
     function setUp() public {
+        ETH_RPC_URL = vm.envOr("ETH_RPC_URL", string(""));
+        vm.skip(bytes(ETH_RPC_URL).length == 0, "ETH_RPC_URL not set");
+
         uint256 forkId = vm.createFork(ETH_RPC_URL);
         vm.selectFork(forkId);
     }

--- a/test/shadowfork/MainnetForkTest.t.sol
+++ b/test/shadowfork/MainnetForkTest.t.sol
@@ -18,7 +18,7 @@ import { DeployAccessManagerWithRoles } from "../../scripts/deployments/DeployAc
 
 contract MainnetForkTest is Test, DeployAccessManagerWithRoles {
     // solhint-disable-next-line var-name-mixedcase
-    string public ETH_RPC_URL;
+    string public ETH_RPC_URL = vm.envString("ETH_RPC_URL");
 
     string public clientId = "cosmoshub-0";
 
@@ -30,9 +30,6 @@ contract MainnetForkTest is Test, DeployAccessManagerWithRoles {
     address public relayer = 0xC4C09A23dDBd1fF0f313885265113F83622284C2;
 
     function setUp() public {
-        ETH_RPC_URL = vm.envOr("ETH_RPC_URL", string(""));
-        vm.skip(bytes(ETH_RPC_URL).length == 0, "ETH_RPC_URL not set");
-
         uint256 forkId = vm.createFork(ETH_RPC_URL);
         vm.selectFork(forkId);
     }


### PR DESCRIPTION
## Summary
- add an IBCRolesLib helper for ICS26 client migration selectors
- expose migrateClient as the migration selector controlled by the admin role

## Test plan
- forge fmt --check contracts/utils/IBCRolesLib.sol
- forge test --match-contract 'ICS02ClientTest|ICS26RouterTest'