### PR TITLE
fix(utils): set a User-Agent on the Tendermint RPC client

### DIFF
--- a/packages/utils/src/rpc.rs
+++ b/packages/utils/src/rpc.rs
@@ -100,6 +100,10 @@ impl TendermintRpcExt for HttpClient {
         )
         .client(
             reqwest_0_11::ClientBuilder::new()
+                // Send an explicit User-Agent. reqwest sends none by default, and some RPC
+                // providers' WAFs (e.g. Lombard / ledger-mainnet-1) reject empty-User-Agent
+                // requests with 403 Forbidden, which surfaces as opaque RPC failures.
+                .user_agent(concat!("ibc-eureka/", env!("CARGO_PKG_VERSION")))
                 .connect_timeout(Duration::from_secs(10))
                 .timeout(Duration::from_secs(30))
                 .pool_idle_timeout(Duration::from_secs(10))

--- a/packages/utils/src/rpc.rs
+++ b/packages/utils/src/rpc.rs
@@ -101,9 +101,8 @@ impl TendermintRpcExt for HttpClient {
         .client(
             reqwest_0_11::ClientBuilder::new()
                 // Send an explicit User-Agent. reqwest sends none by default, and some RPC
-                // providers' WAFs (e.g. Lombard / ledger-mainnet-1) reject empty-User-Agent
-                // requests with 403 Forbidden, which surfaces as opaque RPC failures.
-                .user_agent(concat!("ibc-eureka/", env!("CARGO_PKG_VERSION")))
+                // providers reject empty User-Agent requests with 403 Forbidden.
+                .user_agent("proof-api")
                 .connect_timeout(Duration::from_secs(10))
                 .timeout(Duration::from_secs(30))
                 .pool_idle_timeout(Duration::from_secs(10))


### PR DESCRIPTION
## Problem

`HttpClient::from_rpc_url` (`packages/utils/src/rpc.rs`) — the single helper every Tendermint RPC client in the proof-api and relayer is built from — constructs a custom `reqwest` client but never sets a `User-Agent`. reqwest sends none by default, and some RPC providers' WAFs reject empty-`User-Agent` requests with **403 Forbidden**.

closes: FOU-262

## Fix

Set an explicit `User-Agent` on the reqwest client. One line at the single chokepoint — fixes the proof-api, the relayer, and every chain/module.

## Verification

A proof-api built from this change, pointed **directly** at `mainnet-rpc.lombard-fi.com` (no proxy), returns 200: `Info` for `ledger-mainnet-1 → 1` succeeds where the unpatched build got 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)